### PR TITLE
fix: the protocol message parser in ww_proto in ww_proto.c

### DIFF
--- a/src/generated/ww_proto.c
+++ b/src/generated/ww_proto.c
@@ -63,6 +63,7 @@ int ww_buf_reserve(ww_buf_t *b, size_t additional) {
 static int w_bytes(ww_buf_t *b, const void *src, size_t n) {
     int rc = ww_buf_reserve(b, n);
     if (rc) return rc;
+    if (b->len + n > b->cap) return WW_ERR_OVERFLOW;
     memcpy(b->data + b->len, src, n);
     b->len += n;
     return WW_OK;
@@ -274,6 +275,7 @@ static int rd_string(ww_rd_t *r, char **out) {
     if (rc) return rc;
     if (len == 0) return WW_ERR_BAD_STRING;  /* includes NUL */
     size_t padded = ((size_t)len + 3u) & ~(size_t)3u;
+    if (padded < (size_t)len) return WW_ERR_OVERFLOW;
     rc = rd_need(r, padded);
     if (rc) return rc;
     if (r->buf[r->pos + len - 1] != 0) return WW_ERR_BAD_STRING;


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `src/generated/ww_proto.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `src/generated/ww_proto.c:66` |

**Description**: The protocol message parser in ww_proto.c performs two unchecked memcpy operations using length values derived directly from attacker-controlled protocol message fields. At line 66, 'n' bytes are written into a protocol buffer at offset b->len without verifying that b->len + n does not exceed the buffer's allocated capacity. At line 282, 'len' bytes are copied from the receive buffer into destination 's' without verifying that 'len' does not exceed the destination buffer size. Both operations can write arbitrary amounts of data beyond the end of allocated heap buffers.

## Changes
- `src/generated/ww_proto.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
