### PR TITLE
Add niri focus checking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "niri-ipc"
+version = "26.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a4adbddf4037ce047854d36a60b5bf80a7990b8db2f0a0b9ede7534b0bae09a"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +282,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,9 +386,11 @@ dependencies = [
  "env_logger",
  "libc",
  "log",
+ "niri-ipc",
  "pkg-config",
  "serde",
  "serde_json",
+ "thiserror",
  "wayland-client",
  "wayland-protocols",
  "wayland-protocols-wlr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ egl = []
 vulkan = []
 layer-shell = [
     "dep:anyhow",
+    "dep:thiserror",
     "dep:env_logger",
     "dep:libc",
     "dep:log",
@@ -25,10 +26,12 @@ layer-shell = [
     "dep:wayland-client",
     "dep:wayland-protocols",
     "dep:wayland-protocols-wlr",
+    "dep:niri-ipc",
 ]
 
 [dependencies]
 anyhow = { version = "1.0", optional = true }
+thiserror = { version = "2.0.18", optional = true }
 env_logger = { version = "0.10", optional = true }
 libc = { version = "0.2", optional = true }
 log = { version = "0.4", optional = true }
@@ -37,6 +40,7 @@ serde_json = { version = "1.0", optional = true }
 wayland-client = { version = "0.31", optional = true }
 wayland-protocols = { version = "0.32", features = ["client", "unstable", "staging"], optional = true }
 wayland-protocols-wlr = { version = "0.3", features = ["client"], optional = true }
+niri-ipc = { version = "26.4.0", optional = true }
 
 [build-dependencies]
 cc = "1"

--- a/src/bin/layer_shell/main.rs
+++ b/src/bin/layer_shell/main.rs
@@ -4,7 +4,7 @@
 //! (Hyprland, Sway, Niri, River, …) and registers each output as a
 //! display with the daemon over the waywallen-display UDS protocol.
 
-mod hyprland_watcher;
+mod watcher;
 
 use std::collections::HashMap;
 use std::ffi::{c_void, CStr, CString};
@@ -162,7 +162,7 @@ struct App {
     uds_sock: PathBuf,
     name_prefix: String,
     pointers: HashMap<u32, PointerCtx>,
-    binding_registry: crate::hyprland_watcher::BindingRegistry,
+    binding_registry: watcher::BindingRegistry,
 }
 
 struct PointerCtx {
@@ -189,7 +189,7 @@ impl App {
             uds_sock,
             name_prefix,
             pointers: HashMap::new(),
-            binding_registry: crate::hyprland_watcher::new_registry(),
+            binding_registry: watcher::new_registry(),
         }
     }
 
@@ -1380,7 +1380,7 @@ fn usage() -> ! {
     std::process::exit(2);
 }
 
-fn main() -> anyhow::Result<()> {
+fn main() -> Result<()> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
     let mut socket: Option<PathBuf> = None;
@@ -1415,7 +1415,7 @@ fn main() -> anyhow::Result<()> {
     run(socket, name_prefix)
 }
 
-fn run(socket: PathBuf, name_prefix: String) -> anyhow::Result<()> {
+fn run(socket: PathBuf, name_prefix: String) -> Result<()> {
     let conn = Connection::connect_to_env()
         .context("connect to WAYLAND_DISPLAY — are you running under a Wayland compositor?")?;
     let (globals, mut queue) = registry_queue_init::<App>(&conn).context("registry init")?;
@@ -1423,7 +1423,8 @@ fn run(socket: PathBuf, name_prefix: String) -> anyhow::Result<()> {
 
     let mut app = App::new(socket, name_prefix);
 
-    crate::hyprland_watcher::spawn(app.binding_registry.clone());
+    watcher::hyprland::spawn(app.binding_registry.clone());
+    watcher::niri::spawn(app.binding_registry.clone());
 
     for g in globals.contents().clone_list() {
         match g.interface.as_str() {

--- a/src/bin/layer_shell/watcher/hyprland.rs
+++ b/src/bin/layer_shell/watcher/hyprland.rs
@@ -4,7 +4,7 @@ use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::atomic::Ordering;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc};
 use std::thread;
 use std::time::Duration;
 
@@ -13,12 +13,7 @@ use waywallen_display::{
     WAYWALLEN_WIN_HAS_ACTIVE, WAYWALLEN_WIN_HAS_FULLSCREEN, WAYWALLEN_WIN_HAS_MAXIMIZED,
     WAYWALLEN_WIN_HAS_NON_MINIMIZED,
 };
-
-pub type BindingRegistry = Arc<Mutex<HashMap<String, Arc<OutputBinding>>>>;
-
-pub fn new_registry() -> BindingRegistry {
-    Arc::new(Mutex::new(HashMap::new()))
-}
+use crate::watcher::{handle_return_code, BindingRegistry};
 
 pub fn detect_socket() -> Option<PathBuf> {
     let his = std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE")?;
@@ -87,17 +82,7 @@ fn push_state(registry: &BindingRegistry) {
             waywallen_display::waywallen_display_set_window_state(d, flags)
         });
         if let Some(rc) = rc {
-            if rc >= 0 {
-                log::debug!(
-                    "hyprland_watcher: [{}] window_state flags=0x{flags:x}",
-                    binding.display_name()
-                );
-                continue;
-            }
-            log::warn!(
-                "hyprland_watcher: [{}] send window_state failed: {rc}",
-                binding.display_name()
-            );
+            handle_return_code("hyprland_watcher", rc, flags, &binding);
         }
     }
 }

--- a/src/bin/layer_shell/watcher/mod.rs
+++ b/src/bin/layer_shell/watcher/mod.rs
@@ -1,0 +1,26 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use crate::OutputBinding;
+
+pub mod hyprland;
+pub mod niri;
+
+pub type BindingRegistry = Arc<Mutex<HashMap<String, Arc<OutputBinding>>>>;
+
+pub fn new_registry() -> BindingRegistry {
+    Arc::new(Mutex::new(HashMap::new()))
+}
+
+pub fn handle_return_code(watcher: &'static str, return_code: i32, flags: u32, binding: &Arc<OutputBinding>) {
+    if return_code >= 0 {
+        log::debug!(
+            "{watcher}: [{}] window_state flags=0x{flags:x}",
+            binding.display_name()
+        );
+    } else {
+        log::warn!(
+            "{watcher}: [{}] send window_state failed: {return_code}",
+            binding.display_name()
+        );
+    }
+}

--- a/src/bin/layer_shell/watcher/niri.rs
+++ b/src/bin/layer_shell/watcher/niri.rs
@@ -7,7 +7,7 @@ use niri_ipc::{Event, Request, Response, Window};
 use niri_ipc::socket::Socket;
 use niri_ipc::state::{EventStreamState, EventStreamStatePart, WindowsState, WorkspacesState};
 use thiserror::Error;
-use waywallen_display::{WAYWALLEN_WIN_HAS_ACTIVE, WAYWALLEN_WIN_HAS_FULLSCREEN};
+use waywallen_display::{WAYWALLEN_WIN_HAS_ACTIVE, WAYWALLEN_WIN_HAS_FULLSCREEN, WAYWALLEN_WIN_HAS_NON_MINIMIZED};
 use crate::OutputBinding;
 use crate::watcher::{handle_return_code, BindingRegistry};
 
@@ -106,11 +106,14 @@ fn get_outputs_flags<'a>(
             ).flatten()
         })
 }
+
 // Implementation note: niri can never have an unfocused window - it doesn't support minimization
 // Also, for now, the IPC doesn't report fullscreen / maximize state, so we have to guess for
 // fullscreen and just do without maximization.
 fn window_to_flags(fullscreen: (i32, i32), window: &Window) -> u32 {
-    let mut flags = WAYWALLEN_WIN_HAS_ACTIVE;
+    let mut flags = 0;
+    flags |= WAYWALLEN_WIN_HAS_NON_MINIMIZED;
+    flags |= WAYWALLEN_WIN_HAS_ACTIVE;
     if is_window_fullscreen(fullscreen, window) {
         flags |= WAYWALLEN_WIN_HAS_FULLSCREEN
     } /* else if is_window_maximized(fullscreen, window) {

--- a/src/bin/layer_shell/watcher/niri.rs
+++ b/src/bin/layer_shell/watcher/niri.rs
@@ -55,11 +55,11 @@ fn run_loop(event_socket: Socket, registry: BindingRegistry) {
             log::debug!("niri_watcher: niri event: {:?}", event);
             if matches!(event, Event::WindowLayoutsChanged {..} | Event::WindowOpenedOrChanged { .. } | Event::WindowFocusChanged {..} | Event::WorkspaceActivated {..}) {
                 state.apply(event);
-                log::debug!("niri_watcher: layouts changed, refreshing outputs");
                 registry.lock().map(|registry| {
                     get_outputs_flags(&*registry, &state.workspaces, &state.windows).for_each(|flags| {
                         flags.map(|(output, flags)| {
                             output.with_display(|display| unsafe {
+                                log::debug!("niri_watcher: layout {}: {flags} sent to server", output.display_name());
                                 waywallen_display::waywallen_display_set_window_state(display, flags)
                             }).map_or((), |return_code| {
                                 handle_return_code("niri_watcher", return_code, flags, output);
@@ -91,8 +91,8 @@ fn get_outputs_flags<'a>(
                                 Ok(logical_size) => logical_size.map(|(x, y)| {
                                     let flags = window_to_flags((x as i32, y as i32), active_window);
                                     log::debug!("niri_watcher: {} flags: {flags}", output.display_name());
-                                    let old_flags = output.window_flags().swap(0, Ordering::SeqCst);
-                                    (old_flags != 0).then_some(Ok((output, 0)))
+                                    let old_flags = output.window_flags().swap(flags, Ordering::SeqCst);
+                                    (old_flags != flags).then_some(Ok((output, flags)))
                                 }).flatten(),
                                 Err(error) => Some(Err(error))
                             }

--- a/src/bin/layer_shell/watcher/niri.rs
+++ b/src/bin/layer_shell/watcher/niri.rs
@@ -1,5 +1,5 @@
 use std::path::{Path};
-use std::{thread};
+use std::thread;
 use std::collections::HashMap;
 use std::sync::{Arc, MutexGuard, PoisonError};
 use std::sync::atomic::Ordering;
@@ -53,7 +53,9 @@ fn run_loop(event_socket: Socket, registry: BindingRegistry) {
     loop {
         read_event().map(|event| {
             log::debug!("niri_watcher: niri event: {:?}", event);
-            if matches!(event, Event::WindowLayoutsChanged {..}) {
+            if matches!(event, Event::WindowLayoutsChanged {..} | Event::WindowOpenedOrChanged { .. } | Event::WindowFocusChanged {..} | Event::WorkspacesChanged {..}) {
+                state.apply(event);
+                log::debug!("niri_watcher: layouts changed, refreshing outputs");
                 registry.lock().map(|registry| {
                     get_outputs_flags(&*registry, &state.workspaces, &state.windows).for_each(|flags| {
                         flags.map(|(output, flags)| {
@@ -65,8 +67,9 @@ fn run_loop(event_socket: Socket, registry: BindingRegistry) {
                         }).unwrap_or_else(|error| log::error!("niri_watcher: calculate flag: {error}"))
                     })
                 }).unwrap_or_else(|error| log::error!("niri_watcher: lock registry: {error}"))
+            } else {
+                state.apply(event);
             }
-            state.apply(event);
         }).unwrap_or_else(|error| log::error!("niri_watcher: read event: {error}"));
     }
 }
@@ -79,26 +82,30 @@ fn get_outputs_flags<'a>(
     workspaces_state.workspaces.values()
         .filter_map(|workspace| {
             workspace.is_active.then_some(())?;
-            workspace.active_window_id.map(|active_window_id|
-                workspace.output.as_ref().map(|output|
-                    outputs.get(output).map(|output| {
-                        output.is_registered().then_some(())?;
-                        windows_state.windows.get(&active_window_id).map(|window|
+            workspace.output.as_ref().map(|output|
+                outputs.get(output).map(|output| {
+                    output.is_registered().then_some(())?;
+                    workspace.active_window_id.map(|active_window_id|
+                        windows_state.windows.get(&active_window_id).map(|active_window|
                             match output.logical_size.lock() {
                                 Ok(logical_size) => logical_size.map(|(x, y)| {
-                                    let flags = window_to_flags((x as i32, y as i32), window);
-                                    let old_flags = output.window_flags().swap(flags, Ordering::SeqCst);
-                                    (old_flags != flags).then_some(Ok((output, flags)))
+                                    let flags = window_to_flags((x as i32, y as i32), active_window);
+                                    log::debug!("niri_watcher: {} flags: {flags}", output.display_name());
+                                    let old_flags = output.window_flags().swap(0, Ordering::SeqCst);
+                                    (old_flags != 0).then_some(Ok((output, 0)))
                                 }).flatten(),
                                 Err(error) => Some(Err(error))
                             }
                         ).flatten()
-                    }).flatten()
-                ).flatten()
+                    ).unwrap_or_else(|| {
+                        log::debug!("niri_watcher: {} flags: 0", output.display_name());
+                        let old_flags = output.window_flags().swap(0, Ordering::SeqCst);
+                        (old_flags != 0).then_some(Ok((output, 0)))
+                    })
+                }).flatten()
             ).flatten()
         })
 }
-
 // Implementation note: niri can never have an unfocused window - it doesn't support minimization
 // Also, for now, the IPC doesn't report fullscreen / maximize state, so we have to guess for
 // fullscreen and just do without maximization.

--- a/src/bin/layer_shell/watcher/niri.rs
+++ b/src/bin/layer_shell/watcher/niri.rs
@@ -1,0 +1,118 @@
+use std::path::{Path};
+use std::{thread};
+use std::collections::HashMap;
+use std::sync::{Arc, MutexGuard, PoisonError};
+use std::sync::atomic::Ordering;
+use niri_ipc::{Event, Request, Response, Window};
+use niri_ipc::socket::Socket;
+use niri_ipc::state::{EventStreamState, EventStreamStatePart, WindowsState, WorkspacesState};
+use thiserror::Error;
+use waywallen_display::{WAYWALLEN_WIN_HAS_ACTIVE, WAYWALLEN_WIN_HAS_FULLSCREEN};
+use crate::OutputBinding;
+use crate::watcher::{handle_return_code, BindingRegistry};
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("compositor response: {0}")]
+    CompositorResponse(String),
+    #[error("unexpected response: {0:?}")]
+    UnexpectedResponse(Response),
+}
+
+pub fn detect_socket() -> Option<impl AsRef<Path>> {
+    let niri_socket = std::env::var_os("NIRI_SOCKET")?;
+    let path: &Path = niri_socket.as_ref();
+    if path.exists() {
+        Some(niri_socket)
+    } else {
+        None
+    }
+}
+
+pub fn spawn(registry: BindingRegistry) {
+    let Some(sock) = detect_socket() else {
+        return;
+    };
+    log::info!("niri_watcher: enabled (socket={})", sock.as_ref().display());
+    Socket::connect_to(sock.as_ref()).map(|mut event_socket|
+        event_socket.send(Request::EventStream).map(|reply| match reply {
+            Ok(response) => match response {
+                Response::Handled => {
+                    thread::spawn(move || run_loop(event_socket, registry));
+                },
+                response => log::error!("niri_watcher: {}", Error::UnexpectedResponse(response))
+            }
+            Err(error) => log::error!("niri_watcher: {}", Error::CompositorResponse(error))
+        }).unwrap_or_else(|error| log::error!("niri_watcher: request eventstream: {error}"))
+    ).unwrap_or_else(|error| log::error!("niri_watcher: connect {}: {error}", sock.as_ref().display()))
+}
+
+fn run_loop(event_socket: Socket, registry: BindingRegistry) {
+    let mut state = EventStreamState::default();
+    let mut read_event = event_socket.read_events();
+    loop {
+        read_event().map(|event| {
+            log::debug!("niri_watcher: niri event: {:?}", event);
+            if matches!(event, Event::WindowLayoutsChanged {..}) {
+                registry.lock().map(|registry| {
+                    get_outputs_flags(&*registry, &state.workspaces, &state.windows).for_each(|flags| {
+                        flags.map(|(output, flags)| {
+                            output.with_display(|display| unsafe {
+                                waywallen_display::waywallen_display_set_window_state(display, flags)
+                            }).map_or((), |return_code| {
+                                handle_return_code("niri_watcher", return_code, flags, output);
+                            })
+                        }).unwrap_or_else(|error| log::error!("niri_watcher: calculate flag: {error}"))
+                    })
+                }).unwrap_or_else(|error| log::error!("niri_watcher: lock registry: {error}"))
+            }
+            state.apply(event);
+        }).unwrap_or_else(|error| log::error!("niri_watcher: read event: {error}"));
+    }
+}
+
+fn get_outputs_flags<'a>(
+    outputs: &'a HashMap<String, Arc<OutputBinding>>,
+    workspaces_state: &'a WorkspacesState,
+    windows_state: &'a WindowsState
+) -> impl Iterator<Item = Result<(&'a Arc<OutputBinding>, u32), PoisonError<MutexGuard<'a, Option<(u32, u32)>>>>> {
+    workspaces_state.workspaces.values()
+        .filter_map(|workspace| {
+            workspace.is_active.then_some(())?;
+            workspace.active_window_id.map(|active_window_id|
+                workspace.output.as_ref().map(|output|
+                    outputs.get(output).map(|output| {
+                        output.is_registered().then_some(())?;
+                        windows_state.windows.get(&active_window_id).map(|window|
+                            match output.logical_size.lock() {
+                                Ok(logical_size) => logical_size.map(|(x, y)| {
+                                    let flags = window_to_flags((x as i32, y as i32), window);
+                                    let old_flags = output.window_flags().swap(flags, Ordering::SeqCst);
+                                    (old_flags != flags).then_some(Ok((output, flags)))
+                                }).flatten(),
+                                Err(error) => Some(Err(error))
+                            }
+                        ).flatten()
+                    }).flatten()
+                ).flatten()
+            ).flatten()
+        })
+}
+
+// Implementation note: niri can never have an unfocused window - it doesn't support minimization
+// Also, for now, the IPC doesn't report fullscreen / maximize state, so we have to guess for
+// fullscreen and just do without maximization.
+fn window_to_flags(fullscreen: (i32, i32), window: &Window) -> u32 {
+    let mut flags = WAYWALLEN_WIN_HAS_ACTIVE;
+    if is_window_fullscreen(fullscreen, window) {
+        flags |= WAYWALLEN_WIN_HAS_FULLSCREEN
+    } /* else if is_window_maximized(fullscreen, window) {
+        flags |= WAYWALLEN_WIN_HAS_MAXIMIZED
+    } */
+    flags
+}
+
+// TODO: Waiting on https://github.com/niri-wm/niri/pull/2836 for proper logic
+fn is_window_fullscreen(fullscreen: (i32, i32), window: &Window) -> bool {
+    !window.is_floating && window.layout.window_size == fullscreen
+}

--- a/src/bin/layer_shell/watcher/niri.rs
+++ b/src/bin/layer_shell/watcher/niri.rs
@@ -53,7 +53,7 @@ fn run_loop(event_socket: Socket, registry: BindingRegistry) {
     loop {
         read_event().map(|event| {
             log::debug!("niri_watcher: niri event: {:?}", event);
-            if matches!(event, Event::WindowLayoutsChanged {..} | Event::WindowOpenedOrChanged { .. } | Event::WindowFocusChanged {..} | Event::WorkspacesChanged {..}) {
+            if matches!(event, Event::WindowLayoutsChanged {..} | Event::WindowOpenedOrChanged { .. } | Event::WindowFocusChanged {..} | Event::WorkspaceActivated {..}) {
                 state.apply(event);
                 log::debug!("niri_watcher: layouts changed, refreshing outputs");
                 registry.lock().map(|registry| {


### PR DESCRIPTION
I decided to implement focus checking for niri as well as hyprland, using the niri ipc protocol.
Note that only part of it is implemented due to some flags either being irrelevant in niri or not possible using the current IPC protocol.
For full functionality, we will have to wait on a niri PR to add maximize and fullscreen checking to IPC.