### PR TITLE
fix(gnome): keep top panel visible by not fullscreening renderer source window

### DIFF
--- a/extensions/gnome/renderer/renderer.js
+++ b/extensions/gnome/renderer/renderer.js
@@ -147,7 +147,14 @@ class MonitorRenderer {
         this._window.set_default_size(geom.width, geom.height);
 
         this._window.connect('realize', () => this._onRealize());
-        this._window.fullscreen_on_monitor(this._monitor);
+        // Do not fullscreen the source window. The visible wallpaper is a
+        // Clutter.Clone of this window injected into the desktop background
+        // actor, so the window itself is only a DMA-BUF source surface. The
+        // correct size is already set via width_request/height_request and
+        // set_default_size(), while the native rendering resolution is
+        // negotiated separately (geom * scale). Fullscreening here causes
+        // GNOME Shell to hide the top panel on an empty desktop.
+        // this._window.fullscreen_on_monitor(this._monitor);
         this._window.present();
     }
 


### PR DESCRIPTION
Fixes #24

The renderer source window was being fullscreened with `fullscreen_on_monitor()`. GNOME Shell treats a fullscreen window as covering the monitor and hides the top panel while the desktop is empty. The visible wallpaper is a `Clutter.Clone` of this window rendered in the desktop background actor, so the source window does not need to be fullscreen.

Changes:
- Remove `fullscreen_on_monitor()` from `MonitorRenderer.build()`.
- Add a comment explaining why the call is intentionally skipped.

The window is still sized, positioned, minimized, and kept at the bottom by the existing title hints and extension window manager, so rendering and monitor mapping continue to work as before.

### Tested on
- Fedora 44
- GNOME Shell 50.2 / Wayland
- Intel HD Graphics 6000
- Single `eDP-1` 1920x1080 laptop display

The top panel now remains visible on an empty desktop while the live wallpaper renders normally.