### PR TITLE
feat(gnome): live wallpaper + blur in Activities overview; show on lockscreen

### DIFF
--- a/extensions/gnome/extension/extension.js
+++ b/extensions/gnome/extension/extension.js
@@ -54,7 +54,7 @@ export default class WaywallenExtension extends Extension {
             this._settings.apply();
         }
 
-        this._override = new GnomeShellOverride();
+        this._override = new GnomeShellOverride(this._settings);
 
         // Defer renderer spawn + override install until shell startup
         // animation is past, so we don't fight Main.layoutManager's

--- a/extensions/gnome/extension/gnomeShellOverride.js
+++ b/extensions/gnome/extension/gnomeShellOverride.js
@@ -1,3 +1,5 @@
+import Clutter from 'gi://Clutter';
+import GLib from 'gi://GLib';
 import Meta from 'gi://Meta';
 import Shell from 'gi://Shell';
 
@@ -12,8 +14,9 @@ import * as Wallpaper from './wallpaper.js';
 const APPLICATION_ID = Wallpaper.APPLICATION_ID;
 
 export class GnomeShellOverride {
-    constructor() {
+    constructor(settings) {
         this._injection = new InjectionManager();
+        this._settings = settings;
         // Held by LiveWallpaper -> nothing; we only iterate on disable
         // and let Clutter destruction cascades clean up otherwise.
         // Using a Set (not Map) means we don't need to wire a destroy
@@ -99,19 +102,205 @@ export class GnomeShellOverride {
                 return originalMethod.call(this).filter(a => a.get_n_windows() > 0);
             });
 
+        this._readOverviewPrefs();
+        this._overviewSettingsIds = [];
+        if (this._settings) {
+            for (const key of ['overview-blur', 'overview-blur-strength']) {
+                this._overviewSettingsIds.push(
+                    this._settings.connect(`changed::${key}`,
+                        () => this._onOverviewPrefsChanged()));
+            }
+        }
+
+        this._setupOverviewBackdrop();
+
         if (!Main.sessionMode.isLocked)
             this._reloadBackgrounds();
     }
 
+    _readOverviewPrefs() {
+        this._overviewBlur = this._settings?.get_boolean('overview-blur') ?? true;
+        this._overviewStrength = this._settings?.get_int('overview-blur-strength') ?? 30;
+    }
+
+    _onOverviewPrefsChanged() {
+        this._readOverviewPrefs();
+        // Rebuild so the backdrop clones' blur reflects the new state.
+        this._invalidateOverviewClones();
+        try { this._syncOverviewBackdrop(); } catch (_e) {}
+    }
+
     disable() {
+        for (const id of this._overviewSettingsIds || []) {
+            try { this._settings?.disconnect(id); } catch (_e) {}
+        }
+        this._overviewSettingsIds = [];
         this._injection.clear();
         const actors = [...this._wallpaperActors];
         this._wallpaperActors.clear();
         for (const a of actors) {
+            // Skip LiveWallpapers GNOME already destroyed (their on_destroy
+            // ran and cleaned up); only destroy the still-live ones, so we
+            // never touch an already-disposed object at teardown.
+            let alreadyGone = false;
+            try { alreadyGone = !!a._wwDestroyed; } catch (_e) { alreadyGone = true; }
+            if (alreadyGone)
+                continue;
             try { a.destroy(); } catch (_e) {}
         }
+        this._teardownOverviewBackdrop();
         if (!Main.sessionMode.isLocked)
             this._reloadBackgrounds();
+    }
+
+    // --- Overview backdrop -------------------------------------------------
+    // The overview is a component layered over the workspaces, so its own
+    // background (the dark margin ring around the rounded workspace previews,
+    // normally the stage-bottom SystemBackground) should read as a BLURRED
+    // wallpaper — while the workspace previews themselves stay sharp, since
+    // the wallpaper is a per-workspace concept. We drop a monitor-filling,
+    // blurred renderer clone at the bottom of overviewGroup for those
+    // margins; the opaque WorkspaceBackgrounds (carrying the sharp live
+    // wallpaper via LiveWallpaper) sit above it and cover the center.
+    // overviewGroup is hidden while the overview is closed, so these clones
+    // only paint while it's open.
+    _setupOverviewBackdrop() {
+        try {
+            this._overviewClones = [];
+            this._overviewGroup = Main.layoutManager.overviewGroup;
+            this._overviewBackdropPoll = GLib.timeout_add(
+                GLib.PRIORITY_DEFAULT, 1000, () => {
+                    try { this._syncOverviewBackdrop(); } catch (_e) {}
+                    return GLib.SOURCE_CONTINUE;
+                });
+            try { this._syncOverviewBackdrop(); } catch (_e) {}
+            // Keep our clones correctly stacked: just above blur-my-shell's
+            // overview background group if present (so our wallpaper shows
+            // over its static blur), otherwise at the very bottom. Re-evaluate
+            // on any structural change, because blur-my-shell re-inserts its
+            // own group at index 0 whenever another child is added.
+            const reposition = () => {
+                try { this._repositionOverviewBackdrop(); } catch (_e) {}
+            };
+            this._overviewChildAdded = this._overviewGroup.connect('child-added', reposition);
+            this._overviewChildRemoved = this._overviewGroup.connect('child-removed', reposition);
+        } catch (_e) {}
+    }
+
+    _bmsOverviewGroup() {
+        try {
+            return this._overviewGroup.get_children().find(
+                c => c?.get_name?.() === 'bms-overview-backgroundgroup') ?? null;
+        } catch (_e) {
+            return null;
+        }
+    }
+
+    _repositionOverviewBackdrop() {
+        const group = this._overviewGroup;
+        const bms = this._bmsOverviewGroup();
+        for (const entry of this._overviewClones) {
+            if (entry.clone.get_parent() !== group)
+                continue;
+            try {
+                if (bms)
+                    group.set_child_above_sibling(entry.clone, bms);
+                else
+                    group.set_child_below_sibling(entry.clone, null);
+            } catch (_e) {}
+        }
+    }
+
+    _invalidateOverviewClones() {
+        for (const entry of [...(this._overviewClones || [])]) {
+            try { this._overviewGroup?.remove_child(entry.clone); } catch (_e) {}
+            try { entry.clone.destroy(); } catch (_e) {}
+        }
+        this._overviewClones = [];
+    }
+
+    _syncOverviewBackdrop() {
+        const group = this._overviewGroup;
+
+        const actors = global.get_window_actors(false);
+        const renderers = actors.filter(a =>
+            a?.meta_window?.title?.includes(APPLICATION_ID));
+        const currentSources = new Set(renderers);
+        const nMonitors = global.display.get_n_monitors();
+
+        for (let m = 0; m < nMonitors; m++) {
+            const src = renderers.find(a => a.meta_window.get_monitor() === m);
+            if (!src || src.width <= 0)
+                continue;
+            const geom = global.display.get_monitor_geometry(m);
+            let entry = this._overviewClones.find(c => c.monitor === m);
+            if (!entry || entry.clone.source !== src) {
+                if (entry) {
+                    try { group.remove_child(entry.clone); } catch (_e2) {}
+                    try { entry.clone.destroy(); } catch (_e2) {}
+                    this._overviewClones = this._overviewClones.filter(c => c !== entry);
+                }
+                const clone = new Clutter.Clone({
+                    source: src,
+                    opacity: 0,
+                });
+                // Optionally blur this backdrop (the overview background
+                // behind/around the workspace previews) so it reads as a
+                // blurred wallpaper, while the previews themselves stay sharp.
+                // Shell.BlurEffect is the same primitive blur-my-shell builds
+                // on; ACTOR mode blurs the clone's own pixels.
+                if (this._overviewBlur && this._overviewStrength > 0) {
+                    try {
+                        clone.add_effect(new Shell.BlurEffect({
+                            mode: Shell.BlurMode.ACTOR,
+                            radius: this._overviewStrength,
+                        }));
+                    } catch (_e) {}
+                }
+                group.add_child(clone);
+                clone.ease({
+                    opacity: 255, duration: 400,
+                    mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+                });
+                entry = {clone, monitor: m};
+                this._overviewClones.push(entry);
+            }
+            const sx = geom.width / src.width;
+            const sy = geom.height / src.height;
+            entry.clone.set_position(geom.x, geom.y);
+            entry.clone.set_scale(sx, sy);
+        }
+
+        // prune clones whose renderer disappeared (e.g. it restarted)
+        for (const entry of [...this._overviewClones]) {
+            if (!currentSources.has(entry.clone.source)) {
+                try { group.remove_child(entry.clone); } catch (_e) {}
+                try { entry.clone.destroy(); } catch (_e) {}
+                this._overviewClones = this._overviewClones.filter(c => c !== entry);
+            }
+        }
+
+        this._repositionOverviewBackdrop();
+    }
+
+    _teardownOverviewBackdrop() {
+        try {
+            if (this._overviewBackdropPoll) {
+                GLib.source_remove(this._overviewBackdropPoll);
+                this._overviewBackdropPoll = 0;
+            }
+            for (const id of ['_overviewChildAdded', '_overviewChildRemoved']) {
+                if (this[id]) {
+                    try { this._overviewGroup?.disconnect(this[id]); } catch (_e) {}
+                    this[id] = 0;
+                }
+            }
+            for (const entry of [...(this._overviewClones || [])]) {
+                try { this._overviewGroup?.remove_child(entry.clone); } catch (_e) {}
+                try { entry.clone.destroy(); } catch (_e) {}
+            }
+            this._overviewClones = [];
+        } catch (_e) {}
     }
 
     _reloadBackgrounds() {

--- a/extensions/gnome/extension/metadata.json.in
+++ b/extensions/gnome/extension/metadata.json.in
@@ -11,5 +11,6 @@
         "50"
     ],
     "settings-schema": "org.gnome.shell.extensions.waywallen",
-    "gettext-domain": "waywallen-gnome"
+    "gettext-domain": "waywallen-gnome",
+    "session-modes": ["user", "unlock-dialog"]
 }

--- a/extensions/gnome/extension/prefs.js
+++ b/extensions/gnome/extension/prefs.js
@@ -2,8 +2,11 @@
 // user is likely to want to tweak by hand; the rest stays in gsettings.
 
 import Adw from 'gi://Adw';
+import GLib from 'gi://GLib';
 import Gtk from 'gi://Gtk';
 import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+
+const Gio = imports.gi.Gio;
 
 export default class WaywallenPrefs extends ExtensionPreferences {
     fillPreferencesWindow(window) {
@@ -41,6 +44,53 @@ export default class WaywallenPrefs extends ExtensionPreferences {
         idRow.add_suffix(regen);
         group.add(idRow);
 
+        // --- Overview ---
+        // The live wallpaper in the Activities overview: sharp behind the
+        // workspace previews, optionally blurred like Blur my Shell.
+        const ovGroup = new Adw.PreferencesGroup({title: 'Overview'});
+        page.add(ovGroup);
+
+        const blurRow = new Adw.SwitchRow({
+            title: 'Blur overview background',
+            subtitle: 'Frosted-glass blur over the overview wallpaper.',
+        });
+        settings.bind('overview-blur', blurRow, 'active',
+            Gio.SettingsBindFlags.DEFAULT);
+        ovGroup.add(blurRow);
+
+        const strengthRow = new Adw.SpinRow({
+            title: 'Overview blur strength',
+            subtitle: 'Blur radius in pixels (higher is blurrier).',
+            adjustment: new Gtk.Adjustment({
+                lower: 0, upper: 100,
+                step_increment: 1, page_increment: 5, value: 30,
+            }),
+        });
+        settings.bind('overview-blur-strength', strengthRow, 'value',
+            Gio.SettingsBindFlags.DEFAULT);
+        const syncStrengthSensitive = () =>
+            strengthRow.set_sensitive(blurRow.active);
+        blurRow.connect('notify::active', syncStrengthSensitive);
+        syncStrengthSensitive();
+        ovGroup.add(strengthRow);
+
+        // Linkage hint: the overview blur coexists with Blur my Shell and
+        // pairs well with it. Only surface the hint if it isn't installed.
+        if (!blurMyShellInstalled()) {
+            const bmsRow = new Adw.ActionRow({
+                icon_name: 'dialog-information-symbolic',
+                title: 'Pairs well with Blur my Shell',
+                subtitle: 'For the full frosted-glass look, install Blur my Shell — it also blurs the panel, dash and application windows, and coexists with this extension.',
+            });
+            bmsRow.add_suffix(new Gtk.LinkButton({
+                label: 'extensions.gnome.org',
+                uri: 'https://extensions.gnome.org/extension/3193/blur-my-shell/',
+                valign: Gtk.Align.CENTER,
+            }));
+            ovGroup.add(bmsRow);
+        }
+
+        // --- Advanced ---
         const advGroup = new Adw.PreferencesGroup({title: 'Advanced'});
         page.add(advGroup);
 
@@ -49,9 +99,19 @@ export default class WaywallenPrefs extends ExtensionPreferences {
             subtitle: 'Overlay resolution / fps / window-state on the wallpaper (dev only).',
         });
         settings.bind('show-diagnostics', diagRow, 'active',
-            imports.gi.Gio.SettingsBindFlags.DEFAULT);
+            Gio.SettingsBindFlags.DEFAULT);
         advGroup.add(diagRow);
     }
+}
+
+function blurMyShellInstalled() {
+    const candidates = [
+        GLib.build_filenamev([GLib.get_home_dir(),
+            '.local', 'share', 'gnome-shell', 'extensions', 'blur-my-shell@aunetx']),
+        '/usr/share/gnome-shell/extensions/blur-my-shell@aunetx',
+        '/usr/local/share/gnome-shell/extensions/blur-my-shell@aunetx',
+    ];
+    return candidates.some(p => GLib.file_test(p, GLib.FileTest.IS_DIR));
 }
 
 function generateUuidV4() {

--- a/extensions/gnome/extension/schemas/org.gnome.shell.extensions.waywallen.gschema.xml
+++ b/extensions/gnome/extension/schemas/org.gnome.shell.extensions.waywallen.gschema.xml
@@ -22,5 +22,25 @@
       <summary>Overlay connection / resolution / window-state on the wallpaper</summary>
     </key>
 
+    <key name="overview-blur" type="b">
+      <default>true</default>
+      <summary>Blur the overview background</summary>
+      <description>
+        Apply a gaussian blur to the overview background wallpaper, like
+        Blur my Shell does for the static wallpaper. Pairs well with Blur
+        my Shell (the two are z-ordered to coexist), but does not require it.
+      </description>
+    </key>
+
+    <key name="overview-blur-strength" type="i">
+      <range min="0" max="100"/>
+      <default>30</default>
+      <summary>Overview background blur radius</summary>
+      <description>
+        Gaussian blur radius (in pixels) for the overview background. Higher
+        is blurrier. 0 effectively disables the blur even when it is on.
+      </description>
+    </key>
+
   </schema>
 </schemalist>

--- a/extensions/gnome/extension/wallpaper.js
+++ b/extensions/gnome/extension/wallpaper.js
@@ -92,6 +92,8 @@ class LiveWallpaper extends St.Widget {
                 duration: FADE_IN_MS,
                 mode: Clutter.AnimationMode.EASE_OUT_QUAD,
             });
+            // Black out the gsettings placeholder behind us (see _dimBackdrop).
+            this._dimBackdrop(true);
             // No redraw timer: Clutter.Clone repaints on the source's
             // queue-redraw, i.e. exactly when the renderer commits a buffer.
             return;
@@ -110,6 +112,29 @@ class LiveWallpaper extends St.Widget {
         });
     }
 
+    // The gsettings MetaBackground behind us is a placeholder solid color.
+    // Where the clone has alpha or at clip edges it bleeds through as a
+    // colored veil — most visible in the overview workspace preview, which
+    // renders that content at brightness 0.5. While we are actively covering
+    // the actor, pin the backdrop to black so any bleed reads as shadow.
+    // Restored when the source goes away so lock-screen / fallback still get
+    // the normal dimmed GNOME background.
+    _dimBackdrop(dim) {
+        try {
+            const content = this._backgroundActor?.content;
+            if (!content)
+                return;
+            if (dim) {
+                if (this._origBrightness === undefined)
+                    this._origBrightness = content.brightness;
+                content.brightness = 0;
+            } else if (this._origBrightness !== undefined) {
+                content.brightness = this._origBrightness;
+                this._origBrightness = undefined;
+            }
+        } catch (_e) {}
+    }
+
     _onSourceDestroyed() {
         this._sourceDestroyId = 0;
         this._sourceActor = null;
@@ -123,6 +148,7 @@ class LiveWallpaper extends St.Widget {
             this.opacity = 0;
             try { clone.destroy(); } catch (_e) {}
         }
+        this._dimBackdrop(false);
         this._schedulePoll();
     }
 

--- a/extensions/gnome/extension/wallpaper.js
+++ b/extensions/gnome/extension/wallpaper.js
@@ -17,9 +17,16 @@ export const LiveWallpaper = GObject.registerClass(
 class LiveWallpaper extends St.Widget {
     _init(backgroundActor) {
         super._init({
-            layout_manager: new Clutter.BinLayout(),
-            width: backgroundActor.width,
-            height: backgroundActor.height,
+            // FixedLayout: we position the clone ourselves in vfunc_allocate
+            // (top-left origin, scaled to fill). BinLayout centered the
+            // monitor-sized clone inside the smaller overview preview box,
+            // which misaligned it and made it collapse when the preview
+            // shrank for the app grid.
+            layout_manager: new Clutter.FixedLayout(),
+            // No explicit width/height: MetaBackgroundActor is content-driven,
+            // and its width/height props are 0 in the overview. We expand to
+            // fill whatever the parent allocates and report no preferred size
+            // (see vfuncs) so we don't distort the overview workspace layout.
             x_expand: true,
             y_expand: true,
             opacity: 0,
@@ -38,12 +45,39 @@ class LiveWallpaper extends St.Widget {
         this._tryAttach();
     }
 
+    // Report no preferred size: the clone's natural (monitor) size would
+    // otherwise feed back into the overview workspace-preview layout and
+    // distort it.
+    vfunc_get_preferred_width(_forHeight) {
+        return [0, 0];
+    }
+    vfunc_get_preferred_height(_forWidth) {
+        return [0, 0];
+    }
+
+    // Scale the clone from the top-left to fill our ACTUAL allocation. The
+    // backing actor's width/height props stay 0 in the content-driven overview
+    // path, so the allocation box is the source of truth. Pinning to (0,0)
+    // with pivot (0,0) fills the preview exactly in both the desktop and the
+    // overview (including when the preview shrinks for the app grid).
+    vfunc_allocate(box) {
+        super.vfunc_allocate(box);
+        const clone = this._cloneActor;
+        if (clone && clone.source && clone.source.width > 0) {
+            const sx = box.get_width() / clone.source.width;
+            const sy = box.get_height() / clone.source.height;
+            clone.set_position(0, 0);
+            if (Math.abs((clone.scale_x ?? 1) - sx) > 0.001 ||
+                Math.abs((clone.scale_y ?? 1) - sy) > 0.001)
+                clone.set_scale(sx, sy);
+        }
+    }
+
     _tryAttach() {
         const renderer = this._findRenderer();
         if (renderer) {
             this._cloneActor = new Clutter.Clone({
                 source: renderer,
-                pivot_point: new Graphene.Point({x: 0.5, y: 0.5}),
             });
             this._cloneDestroyId = this._cloneActor.connect('destroy', () => {
                 this._cloneActor = null;
@@ -111,6 +145,11 @@ class LiveWallpaper extends St.Widget {
     }
 
     on_destroy() {
+        // Mark first so GnomeShellOverride.disable() can skip us when GNOME
+        // has already destroyed our parent backgroundActor — avoids the
+        // "already disposed" warning (and any GC-sweep jitter) from a
+        // redundant second destroy() at extension teardown.
+        this._wwDestroyed = true;
         if (this._pollId) {
             GLib.source_remove(this._pollId);
             this._pollId = 0;


### PR DESCRIPTION
## Summary

Makes the **waywallen live wallpaper show in the GNOME Activities overview and on the lockscreen**, with a Blur-my-Shell-style **blurred** overview background. The workspace/window previews keep the **sharp** wallpaper (it's a per-workspace concept); the overview's own background layer — the dark margin ring normally filled by the stage-bottom `SystemBackground` — becomes a **blurred** wallpaper. Coexists with Blur my Shell, but does **not** require it.

## Screenshots

**Activities overview (window picker)** — sharp wallpaper in the previews, blurred wallpaper as the overview background:
<!-- edit this description on GitHub and drag `截图 2026-07-16 16-45-59.png` onto the line below; GitHub uploads it automatically -->
<img width="2559" height="1599" alt="截图 2026-07-16 17-00-57" src="https://github.com/user-attachments/assets/b1b12278-de73-4d12-b1d4-9dca78b86cd2" />


**App grid** — blurred wallpaper as the full background behind the icons:
<!-- drag `截图 2026-07-16 16-46-05.png` onto the line below -->
<img width="2559" height="1599" alt="截图 2026-07-16 17-01-14" src="https://github.com/user-attachments/assets/59277198-d63d-4c4c-8358-d98137de40b2" />


## Changes

**Overview wallpaper + blur** (`gnomeShellOverride.js`, `wallpaper.js`)
- Drop a monitor-filling `Clutter.Clone` of the renderer at the bottom of `overviewGroup` for the overview background, with an optional `Shell.BlurEffect` (ACTOR mode). `overviewGroup` is hidden while the overview is closed, so these clones only paint while it's open.
- Coexists with Blur my Shell: the clone is z-ordered **just above** Blur my Shell's `bms-overview-backgroundgroup` if present (so our wallpaper shows over its static blur), otherwise at the very bottom — re-evaluated on every structural change, because BMS re-inserts its own group at index 0 whenever a child is added.
- **LiveWallpaper sizing fix:** switched from `BinLayout` + center pivot `(0.5, 0.5)` to `FixedLayout` + top-left origin `(0, 0)`. The old setup centered a monitor-sized clone inside the smaller overview preview box and misaligned it — it filled only ~80%, collapsing to ~10% when the preview shrank for the app grid. Now it fills the preview exactly in both the desktop and the overview.

**Lockscreen** (`metadata.json.in`)
- Declare `"session-modes": ["user", "unlock-dialog"]`. Without it, GNOME disables the extension when the screen locks, and `disable()` SIGTERMs the renderer — leaving the lockscreen black until unlock respawns it (with a visible reload fade-in). Traced via `[ww-lock]` logging: at lock, the `screen-shield-background`'s `LiveWallpaper` attaches fine, then the extension is torn down ~7s in and the renderer is killed.

**Settings** (`prefs.js`, `schemas/…gschema.xml`)
- Two new keys, surfaced in a new **Overview** prefs group, **hot-toggleable** (no logout):
  - `overview-blur` (bool, default `true`)
  - `overview-blur-strength` (int `0–100`, default `30`)
- A "Pairs well with Blur my Shell" hint row (with an EGO link) is shown only when Blur my Shell isn't installed.

**Teardown hardening** (`wallpaper.js`, `gnomeShellOverride.js`)
- `LiveWallpaper.on_destroy` sets a `_wwDestroyed` flag; `disable()` skips already-destroyed actors instead of calling `destroy()` on disposed objects, removing logout-time `already disposed` / `JSAPI during GC sweep` jitter that could otherwise cascade into GDM trouble.

## Open questions for the maintainer

I'd like your call on a couple of things before this is merge-shaped:

1. **Always-on vs opt-out.** I initially added an `overview-backdrop` on/off toggle, but making "off" clean turned out tricky: removing the blurred backdrop left the sharp wallpaper that still shows in the app-grid state, so "off" still showed wallpaper. For waywallen users (who want the live wallpaper everywhere) the off-state was also undesirable, so I dropped the toggle and made the overview wallpaper **always on** — only `overview-blur` / strength remain configurable. Happy to re-add a working opt-out toggle if you'd prefer one.
2. **Defaults.** `overview-blur=true`, `overview-blur-strength=30` (matches Blur my Shell's overview radius). Easy to change.
3. **`Shell.BlurEffect` ACTOR mode on NVIDIA.** It's the same primitive Blur my Shell's static blur builds on, and it works on the tested NVIDIA setup — but if you've seen ACTOR-mode issues, I can switch to a two-actor `BACKGROUND`-mode approach.

## Testing

Built/installed locally against GNOME 50 (Wayland, NVIDIA). Verified:
- Overview: sharp wallpaper in previews + blurred wallpaper background; fills the preview 100%; no collapse when shrinking for the app grid.
- App grid: blurred wallpaper background.
- Lockscreen (with WACK-Sonoma): wallpaper shows and stays (no black-out, no reload fade-in).
- Hot-toggling blur on/off and the strength slider takes effect immediately, no logout.
- Clean logout → re-login (no shell crash, no GDM auth flurry).

