### PR TITLE
layer-shell: generic window-state watcher on wlr-foreign-toplevel

### DIFF
--- a/src/bin/layer_shell/main.rs
+++ b/src/bin/layer_shell/main.rs
@@ -1608,9 +1608,7 @@ fn run(socket: PathBuf, name_prefix: String) -> Result<()> {
 
     let mut app = App::new(socket, name_prefix);
 
-    watcher::hyprland::spawn(app.binding_registry.clone());
-    watcher::niri::spawn(app.binding_registry.clone());
-    watcher::wayfire::spawn(app.binding_registry.clone());
+    watcher::spawn_all(app.binding_registry.clone());
 
     for g in globals.contents().clone_list() {
         match g.interface.as_str() {

--- a/src/bin/layer_shell/watcher/mod.rs
+++ b/src/bin/layer_shell/watcher/mod.rs
@@ -5,11 +5,29 @@ use std::sync::{Arc, Mutex};
 pub mod hyprland;
 pub mod niri;
 pub mod wayfire;
+pub mod wlr;
 
 pub type BindingRegistry = Arc<Mutex<HashMap<String, Arc<OutputBinding>>>>;
 
 pub fn new_registry() -> BindingRegistry {
     Arc::new(Mutex::new(HashMap::new()))
+}
+
+/// Starts the one watcher that fits the compositor we are running under.
+///
+/// A compositor with its own IPC gets its own watcher: only that IPC can say
+/// which workspace is visible, and every window on a hidden one has to stay out
+/// of the count. [`wlr`] is the fallback for everything else.
+pub fn spawn_all(registry: BindingRegistry) {
+    if hyprland::detect_socket().is_some() {
+        hyprland::spawn(registry)
+    } else if niri::detect_socket().is_some() {
+        niri::spawn(registry)
+    } else if wayfire::detect_socket().is_some() {
+        wayfire::spawn(registry)
+    } else {
+        wlr::spawn(registry)
+    }
 }
 
 pub fn handle_return_code(

--- a/src/bin/layer_shell/watcher/wlr.rs
+++ b/src/bin/layer_shell/watcher/wlr.rs
@@ -1,0 +1,467 @@
+//! Generic window-state watcher on `zwlr_foreign_toplevel_management_v1`.
+//!
+//! One watcher for every compositor that speaks the protocol but ships no IPC
+//! of its own — Sway, river, labwc, … The handle `state` enum maps onto the
+//! `WAYWALLEN_WIN_HAS_*` bits one for one, and `output_enter` / `output_leave`
+//! give the per-display binding.
+//!
+//! What this cannot do is ask which workspace is visible — the protocol has no
+//! such concept. How much that costs depends on the compositor:
+//!
+//! * Sway drops the window off the output (`output_leave`) as soon as its
+//!   workspace is hidden and puts it back on the way in, so the accounting
+//!   stays exact.
+//! * labwc and niri keep the window on the output and only clear `activated`,
+//!   so a window parked on a hidden desktop still contributes
+//!   `HAS_NON_MINIMIZED`, `HAS_MAXIMIZED` and `HAS_FULLSCREEN`.
+//!
+//! That is why [`crate::watcher::spawn_all`] hands the compositor to its own
+//! watcher whenever there is one and only falls back to this.
+
+use crate::watcher::{handle_return_code, BindingRegistry};
+use crate::OutputBinding;
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::thread;
+use wayland_client::backend::ObjectId;
+use wayland_client::globals::{registry_queue_init, GlobalListContents};
+use wayland_client::protocol::wl_output::{self, WlOutput};
+use wayland_client::protocol::wl_registry::{self, WlRegistry};
+use wayland_client::{event_created_child, Connection, Dispatch, EventQueue, Proxy, QueueHandle};
+use wayland_protocols_wlr::foreign_toplevel::v1::client::{
+    zwlr_foreign_toplevel_handle_v1::{self, State, ZwlrForeignToplevelHandleV1},
+    zwlr_foreign_toplevel_manager_v1::{self, ZwlrForeignToplevelManagerV1},
+};
+use waywallen_display::{
+    WAYWALLEN_WIN_HAS_ACTIVE, WAYWALLEN_WIN_HAS_FULLSCREEN, WAYWALLEN_WIN_HAS_MAXIMIZED,
+    WAYWALLEN_WIN_HAS_NON_MINIMIZED,
+};
+
+const MANAGER_INTERFACE: &str = "zwlr_foreign_toplevel_manager_v1";
+
+/// Version 2 added the `fullscreen` state, version 3 the `parent` event; a
+/// version 1 compositor still drives the other three bits.
+const MANAGER_VERSION: u32 = 3;
+
+/// `wl_output.name` carries the connector string the daemon knows each display
+/// by, and it needs version 4.
+const OUTPUT_VERSION: u32 = 4;
+
+pub fn spawn(registry: BindingRegistry) {
+    let conn = match Connection::connect_to_env() {
+        Ok(conn) => conn,
+        Err(error) => {
+            log::error!("wlr_watcher: connect to compositor: {error}");
+            return;
+        }
+    };
+    let (globals, queue) = match registry_queue_init::<Watcher>(&conn) {
+        Ok(pair) => pair,
+        Err(error) => {
+            log::error!("wlr_watcher: registry init: {error}");
+            return;
+        }
+    };
+    let qh = queue.handle();
+    let mut watcher = Watcher::new(registry);
+    let mut manager = None;
+    for global in globals.contents().clone_list() {
+        match global.interface.as_str() {
+            MANAGER_INTERFACE => {
+                manager = Some(
+                    globals
+                        .registry()
+                        .bind::<ZwlrForeignToplevelManagerV1, _, _>(
+                            global.name,
+                            global.version.min(MANAGER_VERSION),
+                            &qh,
+                            (),
+                        ),
+                )
+            }
+            "wl_output" => {
+                watcher.bind_output(globals.registry(), global.name, global.version, &qh)
+            }
+            _ => {}
+        }
+    }
+    let Some(manager) = manager else {
+        log::debug!("wlr_watcher: compositor does not expose {MANAGER_INTERFACE}");
+        return;
+    };
+    log::info!(
+        "wlr_watcher: enabled ({MANAGER_INTERFACE} v{})",
+        manager.version()
+    );
+    thread::spawn(move || run_loop(queue, watcher, manager));
+}
+
+fn run_loop(
+    mut queue: EventQueue<Watcher>,
+    mut watcher: Watcher,
+    _manager: ZwlrForeignToplevelManagerV1,
+) {
+    // The compositor announces every window it already has, so the first
+    // roundtrip is what fills in the state the daemon starts out with.
+    if let Err(error) = queue.roundtrip(&mut watcher) {
+        log::error!("wlr_watcher: initial roundtrip: {error}");
+        return;
+    }
+    watcher.push_state();
+    loop {
+        if let Err(error) = queue.blocking_dispatch(&mut watcher) {
+            log::error!("wlr_watcher: dispatch: {error}");
+            return;
+        }
+        if std::mem::take(&mut watcher.dirty) {
+            watcher.push_state();
+        }
+    }
+}
+
+struct Watcher {
+    registry: BindingRegistry,
+    outputs: HashMap<ObjectId, Output>,
+    toplevels: HashMap<ObjectId, Toplevel>,
+    dirty: bool,
+}
+
+struct Output {
+    global: u32,
+    display_name: Option<String>,
+}
+
+#[derive(Default)]
+struct Toplevel {
+    outputs: HashSet<ObjectId>,
+    state: WindowState,
+    pending_outputs: HashSet<ObjectId>,
+    pending_state: WindowState,
+}
+
+impl Toplevel {
+    /// `output_enter`, `output_leave` and `state` are double-buffered, so
+    /// nothing is published before `done` — Sway sends a spurious leave/enter
+    /// pair for the same output on every fullscreen toggle, and labwc sends two
+    /// `state` events in one batch when a window is minimized.
+    fn commit(&mut self) -> bool {
+        if self.outputs == self.pending_outputs && self.state == self.pending_state {
+            return false;
+        }
+        self.outputs.clone_from(&self.pending_outputs);
+        self.state = self.pending_state;
+        true
+    }
+}
+
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq)]
+struct WindowState {
+    maximized: bool,
+    minimized: bool,
+    activated: bool,
+    fullscreen: bool,
+}
+
+impl WindowState {
+    /// The payload is a `wl_array` of `zwlr_foreign_toplevel_handle_v1.state`
+    /// values, and every event replaces the previous state wholesale.
+    fn from_event(payload: &[u8]) -> Self {
+        let mut state = Self::default();
+        for value in payload.chunks_exact(4) {
+            let value = u32::from_ne_bytes([value[0], value[1], value[2], value[3]]);
+            match State::try_from(value) {
+                Ok(State::Maximized) => state.maximized = true,
+                Ok(State::Minimized) => state.minimized = true,
+                Ok(State::Activated) => state.activated = true,
+                Ok(State::Fullscreen) => state.fullscreen = true,
+                _ => log::debug!("wlr_watcher: unknown toplevel state {value}"),
+            }
+        }
+        state
+    }
+
+    /// A minimized window is off screen, so it contributes nothing — not even
+    /// `activated`, which labwc keeps set for one event after iconifying.
+    fn to_flags(self) -> u32 {
+        if self.minimized {
+            return 0;
+        }
+        let mut flags = WAYWALLEN_WIN_HAS_NON_MINIMIZED;
+        if self.activated {
+            flags |= WAYWALLEN_WIN_HAS_ACTIVE
+        }
+        if self.maximized {
+            flags |= WAYWALLEN_WIN_HAS_MAXIMIZED
+        }
+        if self.fullscreen {
+            flags |= WAYWALLEN_WIN_HAS_FULLSCREEN
+        }
+        flags
+    }
+}
+
+impl Watcher {
+    fn new(registry: BindingRegistry) -> Self {
+        Self {
+            registry,
+            outputs: HashMap::new(),
+            toplevels: HashMap::new(),
+            dirty: false,
+        }
+    }
+
+    fn bind_output(
+        &mut self,
+        registry: &WlRegistry,
+        global: u32,
+        version: u32,
+        qh: &QueueHandle<Self>,
+    ) {
+        if version < OUTPUT_VERSION {
+            log::warn!(
+                "wlr_watcher: wl_output v{version} has no name event, \
+                 display {global} cannot be matched"
+            );
+            return;
+        }
+        let output = registry.bind::<WlOutput, _, _>(global, OUTPUT_VERSION, qh, ());
+        self.outputs.insert(
+            output.id(),
+            Output {
+                global,
+                display_name: None,
+            },
+        );
+    }
+
+    fn drop_output(&mut self, global: u32) {
+        self.outputs.retain(|_, output| output.global != global);
+        self.dirty = true;
+    }
+
+    fn aggregate_flags(&self) -> HashMap<&str, u32> {
+        let mut by_output: HashMap<&str, u32> = HashMap::new();
+        for toplevel in self.toplevels.values() {
+            let flags = toplevel.state.to_flags();
+            if flags == 0 {
+                continue;
+            }
+            for output in &toplevel.outputs {
+                let Some(display_name) = self
+                    .outputs
+                    .get(output)
+                    .and_then(|output| output.display_name.as_deref())
+                else {
+                    continue;
+                };
+                *by_output.entry(display_name).or_insert(0) |= flags;
+            }
+        }
+        by_output
+    }
+
+    fn push_state(&self) {
+        let by_output = self.aggregate_flags();
+        let bindings: Vec<Arc<OutputBinding>> = match self.registry.lock() {
+            Ok(registry) => registry.values().cloned().collect(),
+            Err(error) => {
+                log::error!("wlr_watcher: lock registry: {error}");
+                return;
+            }
+        };
+        for binding in bindings {
+            let flags = by_output.get(binding.display_name()).copied().unwrap_or(0);
+            if binding.window_flags().swap(flags, Ordering::SeqCst) == flags {
+                continue;
+            }
+            log::debug!("wlr_watcher: {} flags: {flags}", binding.display_name());
+            if !binding.is_registered() {
+                continue;
+            }
+            let return_code = binding.with_display(|display| unsafe {
+                waywallen_display::waywallen_display_set_window_state(display, flags)
+            });
+            if let Some(return_code) = return_code {
+                handle_return_code("wlr_watcher", return_code, flags, &binding);
+            }
+        }
+    }
+}
+
+impl Dispatch<WlRegistry, GlobalListContents> for Watcher {
+    fn event(
+        state: &mut Self,
+        registry: &WlRegistry,
+        event: wl_registry::Event,
+        _: &GlobalListContents,
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        match event {
+            wl_registry::Event::Global {
+                name,
+                interface,
+                version,
+            } if interface == "wl_output" => state.bind_output(registry, name, version, qh),
+            wl_registry::Event::GlobalRemove { name } => state.drop_output(name),
+            _ => {}
+        }
+    }
+}
+
+impl Dispatch<WlOutput, ()> for Watcher {
+    fn event(
+        state: &mut Self,
+        output: &WlOutput,
+        event: wl_output::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let wl_output::Event::Name { name } = event else {
+            return;
+        };
+        let Some(entry) = state.outputs.get_mut(&output.id()) else {
+            return;
+        };
+        log::debug!("wlr_watcher: wl_output {} is '{name}'", entry.global);
+        entry.display_name = Some(name);
+        state.dirty = true;
+    }
+}
+
+impl Dispatch<ZwlrForeignToplevelManagerV1, ()> for Watcher {
+    fn event(
+        state: &mut Self,
+        _: &ZwlrForeignToplevelManagerV1,
+        event: zwlr_foreign_toplevel_manager_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        match event {
+            zwlr_foreign_toplevel_manager_v1::Event::Toplevel { toplevel } => {
+                state.toplevels.insert(toplevel.id(), Toplevel::default());
+            }
+            zwlr_foreign_toplevel_manager_v1::Event::Finished => {
+                log::info!("wlr_watcher: compositor stopped the toplevel manager");
+                state.toplevels.clear();
+                state.dirty = true;
+            }
+            _ => {}
+        }
+    }
+
+    event_created_child!(Watcher, ZwlrForeignToplevelManagerV1, [
+        zwlr_foreign_toplevel_manager_v1::EVT_TOPLEVEL_OPCODE => (ZwlrForeignToplevelHandleV1, ()),
+    ]);
+}
+
+impl Dispatch<ZwlrForeignToplevelHandleV1, ()> for Watcher {
+    fn event(
+        state: &mut Self,
+        handle: &ZwlrForeignToplevelHandleV1,
+        event: zwlr_foreign_toplevel_handle_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let handle_id = handle.id();
+        if let zwlr_foreign_toplevel_handle_v1::Event::Closed = event {
+            handle.destroy();
+            state.toplevels.remove(&handle_id);
+            state.dirty = true;
+            return;
+        }
+        let Some(toplevel) = state.toplevels.get_mut(&handle_id) else {
+            return;
+        };
+        let changed = match event {
+            zwlr_foreign_toplevel_handle_v1::Event::OutputEnter { output } => {
+                toplevel.pending_outputs.insert(output.id());
+                false
+            }
+            zwlr_foreign_toplevel_handle_v1::Event::OutputLeave { output } => {
+                toplevel.pending_outputs.remove(&output.id());
+                false
+            }
+            zwlr_foreign_toplevel_handle_v1::Event::State { state: reported } => {
+                toplevel.pending_state = WindowState::from_event(&reported);
+                false
+            }
+            zwlr_foreign_toplevel_handle_v1::Event::Done => {
+                let changed = toplevel.commit();
+                if changed {
+                    log::debug!(
+                        "wlr_watcher: toplevel {handle_id} flags {} on {} output(s)",
+                        toplevel.state.to_flags(),
+                        toplevel.outputs.len()
+                    );
+                }
+                changed
+            }
+            _ => false,
+        };
+        state.dirty |= changed;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn payload(states: &[State]) -> Vec<u8> {
+        states
+            .iter()
+            .flat_map(|state| (*state as u32).to_ne_bytes())
+            .collect()
+    }
+
+    #[test]
+    fn empty_state_is_a_plain_window() {
+        let state = WindowState::from_event(&payload(&[]));
+        assert_eq!(state, WindowState::default());
+        assert_eq!(state.to_flags(), WAYWALLEN_WIN_HAS_NON_MINIMIZED);
+    }
+
+    #[test]
+    fn every_state_maps_onto_its_bit() {
+        assert_eq!(
+            WindowState::from_event(&payload(&[State::Activated])).to_flags(),
+            WAYWALLEN_WIN_HAS_NON_MINIMIZED | WAYWALLEN_WIN_HAS_ACTIVE
+        );
+        assert_eq!(
+            WindowState::from_event(&payload(&[State::Maximized, State::Activated])).to_flags(),
+            WAYWALLEN_WIN_HAS_NON_MINIMIZED
+                | WAYWALLEN_WIN_HAS_ACTIVE
+                | WAYWALLEN_WIN_HAS_MAXIMIZED
+        );
+        assert_eq!(
+            WindowState::from_event(&payload(&[State::Activated, State::Fullscreen])).to_flags(),
+            WAYWALLEN_WIN_HAS_NON_MINIMIZED
+                | WAYWALLEN_WIN_HAS_ACTIVE
+                | WAYWALLEN_WIN_HAS_FULLSCREEN
+        );
+    }
+
+    #[test]
+    fn minimized_windows_contribute_nothing() {
+        assert_eq!(
+            WindowState::from_event(&payload(&[State::Minimized, State::Activated])).to_flags(),
+            0
+        );
+        assert_eq!(
+            WindowState::from_event(&payload(&[State::Minimized])).to_flags(),
+            0
+        );
+    }
+
+    #[test]
+    fn a_truncated_array_is_ignored() {
+        assert_eq!(
+            WindowState::from_event(&[0x02, 0x00, 0x00]),
+            WindowState::default()
+        );
+    }
+}


### PR DESCRIPTION
Implements option B from #30 — one generic
`zwlr_foreign_toplevel_management_v1` watcher instead of a new watcher per
compositor. Sway, river and labwc had no window-state watcher at all, so
`set_window_state` was never called and auto pause never triggered there.

### What is in here

`watcher/wlr.rs` binds the manager global on its own Wayland connection and
runs its own thread, like the other watchers. The handle `state` enum maps
onto the `WAYWALLEN_WIN_HAS_*` bits one for one, `output_enter` /
`output_leave` give the per-display binding, and `wl_output.name` is what ties
a handle to the display name the daemon knows. No new dependency:
`wayland-protocols-wlr` is already in the tree for the layer shell.

`watcher/mod.rs` gains `spawn_all()`, which replaces the three `spawn` calls in
`main.rs`. It hands the compositor to its own watcher when there is one and
only falls back to the generic path otherwise — see the workspace section
below for why the order matters.

State and output membership are double-buffered until `done`, because a single
batch can contradict itself: Sway sends an `output_leave` immediately followed
by an `output_enter` for the *same* output on every fullscreen toggle, and
labwc sends two `state` events in one batch when a window is iconified
(`minimized activated`, then `minimized`).

Four unit tests cover the `wl_array` decode and the flag mapping. They live
next to the existing Wayfire ones — which, I noticed, never run: the `[[bin]]`
section sets `test = false`, so `cargo test` reports 0 tests and only
`cargo clippy --all-targets` ever compiles them. I left that alone; say the
word if you want a separate target for it.

### The visible-workspace question, measured

#30 assumed the generic path would over-report windows on hidden workspaces.
That turns out to be compositor-dependent, so I measured it instead of
guessing. Nested sessions, one window per output, watching what the daemon is
actually told:

| compositor | `output_leave` when the workspace is hidden? | result |
| --- | --- | --- |
| Sway 1.12 | yes, and `output_enter` on the way back | exact, no over-report |
| labwc 0.20.1 | no, only `activated` is cleared | `HAS_NON_MINIMIZED` / `HAS_MAXIMIZED` / `HAS_FULLSCREEN` linger |
| niri 26.04 | no, only `activated` is cleared | same |

Sway, switching the output to an empty workspace and back (from the shipping
binary, `RUST_LOG=waywallen_layer_shell::watcher=debug`):

    ==== open B on WL-1 / workspace 2
    wlr_watcher: toplevel …@4278190080 flags 3 on 1 output(s)
    wlr_watcher: WL-1 flags: 3
    ==== WL-1 -> empty workspace 9
    wlr_watcher: toplevel …@4278190080 flags 1 on 0 output(s)
    wlr_watcher: WL-1 flags: 0
    ==== WL-1 -> back to workspace 2
    wlr_watcher: toplevel …@4278190080 flags 3 on 1 output(s)
    wlr_watcher: WL-1 flags: 3

labwc, the same switch:

    ==== GoToDesktop right (hidden desktop)
    wlr_watcher: toplevel …@4278190081 flags 1 on 1 output(s)
    wlr_watcher: WL-1 flags: 1

So on Sway the accounting is exact and nothing is lost against a hand-written
Sway watcher. On labwc a window parked on a hidden desktop keeps the wallpaper
paused; `HAS_ACTIVE` stays correct everywhere. That is the whole behavioural
difference, and it is written down in the module doc comment. It is also why
`spawn_all()` still prefers the compositor's own watcher when one exists.

### The bits are not read off the spec

All four, from the shipping binary under labwc (which has both maximize and
iconify), flags in decimal:

    ==== open C            WL-1 flags: 3    non-minimized + active
    ==== maximize (W-x)    WL-1 flags: 7    + maximized
    ==== fullscreen (W-f)  WL-1 flags: 15   + fullscreen
    ==== unfullscreen      WL-1 flags: 7
    ==== unmaximize        WL-1 flags: 3
    ==== minimize (W-m)    toplevel flags 0 — the window drops out of the count

And output binding under Sway with two outputs, moving the window across:

    ==== move A to WL-2
    wlr_watcher: WL-1 flags: 0
    wlr_watcher: WL-2 flags: 1

### niri — your call

The generic watcher would be strictly better than `watcher/niri.rs` on two
counts and worse on one, so I have left `niri.rs` in charge and am asking
rather than switching it silently.

Better: niri reports `Maximized` honestly over the wlr protocol — `niri.rs`
never sets `HAS_MAXIMIZED` at all — and it reports `Fullscreen` honestly,
where `niri.rs` guesses by comparing the window size to the output size while
waiting on niri-wm/niri#2836 (still open). Measured on niri 26.04: a tiled
window reports `MAXIMIZED ACTIVATED`, and the bit clears the moment the window
is made floating.

Worse: `niri.rs` filters by the active workspace and the generic path cannot,
per the table above.

Flipping it is one line in `spawn_all()`. Which trade do you prefer?

### COSMIC is still not covered

`cosmic-comp` does not implement `zwlr_foreign_toplevel_management_v1` —
`src/wayland/protocols/` has `toplevel_info.rs` and `toplevel_management.rs`,
but those are its own `zcosmic_toplevel_*` protocols, and the only standard
one it speaks is `ext_foreign_toplevel_list_v1`, which carries no state and no
output binding. So COSMIC needs the separate watcher sketched in #30, with the
GPL-3.0-only `cosmic-protocols` crate replaced by a vendored XML. Happy to
write it as a follow-up if you want it.

### Testing

I develop on KDE, so everything above was run in nested sessions rather than
as a daily driver: Sway 1.12 (two outputs via `WLR_WL_OUTPUTS=2`), labwc
0.20.1, niri 26.04. river 0.4.6 exposes the manager global at version 3, but I
could not exercise it — river 0.4 maps no windows without an external
`river_window_manager_v1` client, and it closed the wallpaper layer surface for
the same reason.

`cargo build`, `cargo fmt --check` and `cargo test` are clean.
`cargo clippy --all-targets` reports the same 14 / 16 warnings as `main` — the
new file adds none.
