### PR TITLE
add reconnect backoff for missed daemon signals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,12 @@ if(WAYWALLEN_DISPLAY_BUILD_TESTS)
         target_compile_options(test_presentation_state PRIVATE
             -Wall -Wextra -Wpedantic)
         add_test(NAME test_presentation_state COMMAND test_presentation_state)
+
+        add_executable(test_reconnect_backoff tests/test_reconnect_backoff.cpp)
+        target_compile_features(test_reconnect_backoff PRIVATE cxx_std_17)
+        target_compile_options(test_reconnect_backoff PRIVATE
+            -Wall -Wextra -Wpedantic)
+        add_test(NAME test_reconnect_backoff COMMAND test_reconnect_backoff)
     endif()
 
     if(WAYWALLEN_DISPLAY_WITH_EGL)

--- a/plugins/qml/WaywallenDisplay.cpp
+++ b/plugins/qml/WaywallenDisplay.cpp
@@ -31,6 +31,14 @@
 
 Q_LOGGING_CATEGORY(lcWD, "waywallen.display")
 
+namespace {
+// Backoff bounds for the reconnect fallback timer (see
+// WaywallenDisplay::scheduleReconnectBackoff). Mirrors the layer-shell
+// client's reconnect schedule (src/bin/layer_shell/main.rs).
+constexpr int kReconnectInitialDelayMs = 2000;
+constexpr int kReconnectMaxDelayMs     = 30000;
+} // namespace
+
 class RenderSessionResources {
 public:
     ~RenderSessionResources() {
@@ -529,6 +537,9 @@ WaywallenDisplay::WaywallenDisplay(QQuickItem* parent): QQuickItem(parent) {
     m_updateSizeTimer.setSingleShot(true);
     m_updateSizeTimer.setInterval(100);
     connect(&m_updateSizeTimer, &QTimer::timeout, this, &WaywallenDisplay::pushSizeUpdate);
+
+    m_reconnectTimer.setSingleShot(true);
+    connect(&m_reconnectTimer, &QTimer::timeout, this, &WaywallenDisplay::onReconnectTimer);
 }
 
 WaywallenDisplay::~WaywallenDisplay() { cleanup(); }
@@ -610,6 +621,12 @@ void WaywallenDisplay::cleanup() {
     m_updateSizeTimer.stop();
     m_lastPushedWidth  = -1;
     m_lastPushedHeight = -1;
+
+    // Reconnect backoff is rearmed explicitly by callers that still
+    // want it (tryConnect failure, handleDisconnect); stopping it here
+    // covers destruction and any other cleanup() caller so no timeout
+    // fires after teardown.
+    m_reconnectTimer.stop();
 
     m_eglImagesValid    = false;
     m_glTexturesCreated = false;
@@ -940,6 +957,14 @@ void WaywallenDisplay::setConnState(ConnState s) {
     if (m_connState == s) return;
     m_connState = s;
     emit connStateChanged();
+    if (s == Connected) {
+        // A healthy connection means any prior backoff was
+        // pessimistic; drop the pending timer (if any) and reset the
+        // delay so the next disconnect starts fast again instead of
+        // inheriting a stretched-out delay from an old outage.
+        m_reconnectTimer.stop();
+        m_reconnectDelayMs = kReconnectInitialDelayMs;
+    }
     // Re-send any post-handshake state that's only valid against a
     // Connected daemon: window_state (autopause reporter) carries the
     // most recent QML-visible bitmask, which the lib does not
@@ -1195,7 +1220,26 @@ void WaywallenDisplay::onDaemonReadySignal() {
 void WaywallenDisplay::requestReconnect() {
     if (m_connState == Connected || m_connState == Handshaking) return;
     if (! m_autoReconnect) return;
+    // Cancel any pending backoff tick so the DBus fast-path and the
+    // timer never race into two overlapping tryConnect() calls.
+    m_reconnectTimer.stop();
     tryConnect();
+}
+
+void WaywallenDisplay::onReconnectTimer() {
+    if (m_connState == Connected || m_connState == Handshaking) return;
+    if (! m_autoReconnect) return;
+    tryConnect();
+}
+
+void WaywallenDisplay::scheduleReconnectBackoff() {
+    if (! m_autoReconnect) return;
+    if (m_connState == Connected || m_connState == Handshaking) return;
+    if (m_reconnectTimer.isActive()) return;
+    const int delay = m_reconnectDelayMs;
+    m_reconnectTimer.start(delay);
+    m_reconnectDelayMs = qMin(delay * 2, kReconnectMaxDelayMs);
+    qCInfo(lcWD, "reconnect backoff scheduled in %d ms", delay);
 }
 
 void WaywallenDisplay::onWindowReady() {
@@ -1401,12 +1445,13 @@ void WaywallenDisplay::tryConnect() {
                                         &metrics);
 
     if (rc != WAYWALLEN_OK) {
-        qCWarning(lcWD, "begin_connect failed: %d (waiting for daemon DBus signal)", rc);
+        qCWarning(lcWD, "begin_connect failed: %d (will retry)", rc);
         waywallen_display_free(display);
         resources->display = nullptr;
         QMutexLocker lock(&m_resourcesMutex);
         if (m_renderResources == resources) m_renderResources.reset();
         setConnState(Disconnected);
+        scheduleReconnectBackoff();
         return;
     }
 
@@ -1425,6 +1470,7 @@ void WaywallenDisplay::tryConnect() {
         QMutexLocker lock(&m_resourcesMutex);
         if (m_renderResources == resources) m_renderResources.reset();
         setConnState(Disconnected);
+        scheduleReconnectBackoff();
         return;
     }
 
@@ -1652,15 +1698,18 @@ void WaywallenDisplay::releaseEglFrame(int releaseSyncobjFd, bool afterGpuWork, 
 
 void WaywallenDisplay::handleDisconnect(int errCode, const char* msg) {
     qCWarning(lcWD,
-              "disconnected (err=%d msg=%s) — waiting for daemon DBus signal",
+              "disconnected (err=%d msg=%s) — will retry",
               errCode,
               msg ? msg : "(null)");
     cleanup();
     setConnState(Disconnected);
     setStreamState(Inactive);
     update();
-    // No retry timer — wait for org.waywallen.waywallen.Daemon NameOwnerChanged
-    // / Ready signals to drive the next attempt (see setupDBusWatcher).
+    // DBus NameOwnerChanged / Ready (see setupDBusWatcher) drive an
+    // immediate retry when the daemon reappears; the backoff timer
+    // below is the fallback for when that signal is missed or the
+    // session bus is unavailable.
+    scheduleReconnectBackoff();
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/qml/WaywallenDisplay.cpp
+++ b/plugins/qml/WaywallenDisplay.cpp
@@ -31,10 +31,11 @@
 
 Q_LOGGING_CATEGORY(lcWD, "waywallen.display")
 
-namespace {
+namespace
+{
 constexpr int kReconnectInitialDelayMs = 2000;
 constexpr int kReconnectMaxDelayMs     = 30000;
-}
+} // namespace
 
 class RenderSessionResources {
 public:
@@ -1690,10 +1691,7 @@ void WaywallenDisplay::releaseEglFrame(int releaseSyncobjFd, bool afterGpuWork, 
 }
 
 void WaywallenDisplay::handleDisconnect(int errCode, const char* msg) {
-    qCWarning(lcWD,
-              "disconnected (err=%d msg=%s) — will retry",
-              errCode,
-              msg ? msg : "(null)");
+    qCWarning(lcWD, "disconnected (err=%d msg=%s) — will retry", errCode, msg ? msg : "(null)");
     cleanup();
     setConnState(Disconnected);
     setStreamState(Inactive);

--- a/plugins/qml/WaywallenDisplay.cpp
+++ b/plugins/qml/WaywallenDisplay.cpp
@@ -32,12 +32,9 @@
 Q_LOGGING_CATEGORY(lcWD, "waywallen.display")
 
 namespace {
-// Backoff bounds for the reconnect fallback timer (see
-// WaywallenDisplay::scheduleReconnectBackoff). Mirrors the layer-shell
-// client's reconnect schedule (src/bin/layer_shell/main.rs).
 constexpr int kReconnectInitialDelayMs = 2000;
 constexpr int kReconnectMaxDelayMs     = 30000;
-} // namespace
+}
 
 class RenderSessionResources {
 public:
@@ -958,10 +955,6 @@ void WaywallenDisplay::setConnState(ConnState s) {
     m_connState = s;
     emit connStateChanged();
     if (s == Connected) {
-        // A healthy connection means any prior backoff was
-        // pessimistic; drop the pending timer (if any) and reset the
-        // delay so the next disconnect starts fast again instead of
-        // inheriting a stretched-out delay from an old outage.
         m_reconnectTimer.stop();
         m_reconnectDelayMs = kReconnectInitialDelayMs;
     }

--- a/plugins/qml/WaywallenDisplay.hpp
+++ b/plugins/qml/WaywallenDisplay.hpp
@@ -226,7 +226,7 @@ private:
     void                                    handleDisconnect(int errCode, const char* msg);
     // Backoff fallback for missed NameOwnerChanged / Ready signals
     // (e.g. daemon already up before setupDBusWatcher subscribed).
-    void                                    scheduleReconnectBackoff();
+    void     scheduleReconnectBackoff();
     void     applyPresentationSnapshot(const waywallen_presentation_snapshot_t& presentation);
     void     applyPresentationState(const waywallen_presentation_state_t& state);
     void     resetPresentation();

--- a/plugins/qml/WaywallenDisplay.hpp
+++ b/plugins/qml/WaywallenDisplay.hpp
@@ -170,9 +170,8 @@ public:
 
     // Attempt to connect now. No-op when already Connected. Triggered
     // automatically by the DBus NameOwnerChanged / Daemon Ready signals
-    // (see setupDBusWatcher); also exposed for tests and manual cues.
-    // There is no internal retry timer — recovery relies entirely on
-    // DBus signals fired when the daemon re-appears.
+    // (see setupDBusWatcher) and by the internal backoff timer (see
+    // scheduleReconnectBackoff); also exposed for tests and manual cues.
     Q_INVOKABLE void requestReconnect();
 
     bool eventFilter(QObject* obj, QEvent* event) override;
@@ -210,6 +209,7 @@ private slots:
     void onDaemonNameOwnerChanged(const QString& name, const QString& oldOwner,
                                   const QString& newOwner);
     void onDaemonReadySignal();
+    void onReconnectTimer();
     void pushSizeUpdate();
 
 private:
@@ -224,6 +224,13 @@ private:
     void                                    setupDBusWatcher();
     void                                    flushPendingRelease();
     void                                    handleDisconnect(int errCode, const char* msg);
+    // Single-shot backoff fallback for when the DBus NameOwnerChanged /
+    // Ready signals are missed (e.g. the daemon was already up and
+    // Ready before setupDBusWatcher subscribed). No-op if already
+    // connected/handshaking, auto-reconnect is off, or a retry is
+    // already pending. Delay doubles up to a cap each time it fires;
+    // resets once a connection succeeds.
+    void                                    scheduleReconnectBackoff();
     void     applyPresentationSnapshot(const waywallen_presentation_snapshot_t& presentation);
     void     applyPresentationState(const waywallen_presentation_state_t& state);
     void     resetPresentation();
@@ -319,6 +326,12 @@ private:
     int      m_lastPushedWidth { -1 };
     int      m_lastPushedHeight { -1 };
     uint32_t m_lastPushedRefreshMhz { 0 };
+
+    // Backoff fallback for reconnect (see scheduleReconnectBackoff).
+    // Single-shot; delay doubles on each failure up to a cap and
+    // resets to the initial value once connected.
+    QTimer m_reconnectTimer;
+    int    m_reconnectDelayMs { 2000 };
 
     // Backend detected from Qt's scene graph.
     enum ActiveBackend

--- a/plugins/qml/WaywallenDisplay.hpp
+++ b/plugins/qml/WaywallenDisplay.hpp
@@ -224,12 +224,8 @@ private:
     void                                    setupDBusWatcher();
     void                                    flushPendingRelease();
     void                                    handleDisconnect(int errCode, const char* msg);
-    // Single-shot backoff fallback for when the DBus NameOwnerChanged /
-    // Ready signals are missed (e.g. the daemon was already up and
-    // Ready before setupDBusWatcher subscribed). No-op if already
-    // connected/handshaking, auto-reconnect is off, or a retry is
-    // already pending. Delay doubles up to a cap each time it fires;
-    // resets once a connection succeeds.
+    // Backoff fallback for missed NameOwnerChanged / Ready signals
+    // (e.g. daemon already up before setupDBusWatcher subscribed).
     void                                    scheduleReconnectBackoff();
     void     applyPresentationSnapshot(const waywallen_presentation_snapshot_t& presentation);
     void     applyPresentationState(const waywallen_presentation_state_t& state);
@@ -328,8 +324,6 @@ private:
     uint32_t m_lastPushedRefreshMhz { 0 };
 
     // Backoff fallback for reconnect (see scheduleReconnectBackoff).
-    // Single-shot; delay doubles on each failure up to a cap and
-    // resets to the initial value once connected.
     QTimer m_reconnectTimer;
     int    m_reconnectDelayMs { 2000 };
 

--- a/tests/test_reconnect_backoff.cpp
+++ b/tests/test_reconnect_backoff.cpp
@@ -7,7 +7,7 @@ static constexpr int kMaxMs     = 30000;
 
 static int advance(int& delay) {
     const int d = delay;
-    delay        = std::min(d * 2, kMaxMs);
+    delay       = std::min(d * 2, kMaxMs);
     return d;
 }
 

--- a/tests/test_reconnect_backoff.cpp
+++ b/tests/test_reconnect_backoff.cpp
@@ -1,0 +1,43 @@
+#include <algorithm>
+#include <cassert>
+#include <cstdio>
+
+static constexpr int kInitialMs = 2000;
+static constexpr int kMaxMs     = 30000;
+
+static int advance(int& delay) {
+    const int d = delay;
+    delay        = std::min(d * 2, kMaxMs);
+    return d;
+}
+
+static void test_delay_doubles_to_cap() {
+    int d = kInitialMs;
+    assert(advance(d) == 2000);
+    assert(advance(d) == 4000);
+    assert(advance(d) == 8000);
+    assert(advance(d) == 16000);
+    assert(advance(d) == 30000);
+    assert(advance(d) == 30000);
+}
+
+static void test_reset_restores_initial() {
+    int d = kInitialMs;
+    advance(d);
+    advance(d);
+    d = kInitialMs;
+    assert(advance(d) == 2000);
+}
+
+static void test_cap_is_never_exceeded() {
+    int d = kInitialMs;
+    for (int i = 0; i < 20; ++i) assert(advance(d) <= kMaxMs);
+}
+
+int main() {
+    test_delay_doubles_to_cap();
+    test_reset_restores_initial();
+    test_cap_is_never_exceeded();
+    std::puts("test_reconnect_backoff: OK");
+    return 0;
+}


### PR DESCRIPTION
## Problem

On login (tested on Arch Linux with KDE Plasma), waywallen-display
failed to connect to the daemon if it was already running before the
QML plugin finished setting up its DBus watcher. The plugin received
no NameOwnerChanged or Ready signal after subscribing, so it sat
disconnected indefinitely — wallpapers were only restored after
manually restarting plasma-plasmashell.service.

## Solution

Add a single-shot backoff timer as a fallback alongside the existing
DBus-driven path. When tryConnect() fails or handleDisconnect() fires,
scheduleReconnectBackoff() arms the timer with an exponentially growing
delay (starting at 2 s, capped at 30 s). If a DBus signal arrives
first, requestReconnect() cancels the pending timer and retries
immediately — the two paths do not race.

The delay resets to the initial value on a successful connection, so
a normal startup (daemon present and signalling) is unaffected.