### PR TITLE
display: add default wallpaper when no frame is presented

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,6 +416,11 @@ if(WAYWALLEN_DISPLAY_PLUGIN_QML)
         COMPONENT kde_extension
         EXCLUDE_FROM_ALL
         PATTERN "Wrapper" EXCLUDE)
+    install(FILES
+        "${CMAKE_SOURCE_DIR}/data/icons/hicolor/scalable/apps/waywallen.svg"
+        DESTINATION org.waywallen.kde/contents/images
+        COMPONENT kde_extension
+        EXCLUDE_FROM_ALL)
 
     if(WAYWALLEN_DISPLAY_QML_URI MATCHES "Embed")
         set(_ww_kde_wrapper_suffix "Embed")

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,6 +24,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +43,24 @@ checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
  "libloading",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -48,6 +84,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +106,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +123,12 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "digest"
@@ -122,10 +179,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
 name = "generic-array"
@@ -170,6 +261,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
+name = "imagesize"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +282,17 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "kurbo"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
 
 [[package]]
 name = "lazy_static"
@@ -259,6 +367,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "niri-ipc"
 version = "26.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +384,15 @@ checksum = "6a4adbddf4037ce047854d36a60b5bf80a7990b8db2f0a0b9ede7534b0bae09a"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -298,10 +425,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -360,12 +506,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "resvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
+dependencies = [
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -428,10 +603,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
 
 [[package]]
 name = "syn"
@@ -480,6 +695,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +731,28 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "usvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "xmlwriter",
+]
 
 [[package]]
 name = "version_check"
@@ -517,7 +780,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "rustix",
  "wayland-backend",
  "wayland-scanner",
@@ -529,7 +792,7 @@ version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -541,7 +804,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -584,6 +847,7 @@ dependencies = [
  "md-5",
  "niri-ipc",
  "pkg-config",
+ "resvg",
  "serde",
  "serde_json",
  "thiserror",
@@ -637,6 +901,12 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ md-5 = { version = "0.10", optional = true }
 [build-dependencies]
 cc = "1"
 pkg-config = "0.3"
+resvg = { version = "0.45", default-features = false }
 
 [[bin]]
 name = "waywallen-layer-shell"

--- a/build.rs
+++ b/build.rs
@@ -37,6 +37,7 @@ fn main() {
 
     if layer_shell {
         compile_layer_shell_shaders(&manifest_dir, &out_dir);
+        rasterize_empty_wallpaper(&manifest_dir, &out_dir);
     }
 
     let mut build = cc::Build::new();
@@ -99,6 +100,41 @@ fn main() {
     ] {
         println!("cargo:rerun-if-changed={f}");
     }
+}
+
+fn rasterize_empty_wallpaper(manifest_dir: &Path, out_dir: &Path) {
+    let svg_path = manifest_dir.join("data/icons/hicolor/scalable/apps/waywallen.svg");
+    println!("cargo:rerun-if-changed={}", svg_path.display());
+    let svg = fs::read(&svg_path).unwrap_or_else(|error| {
+        panic!("read {}: {error}", svg_path.display());
+    });
+    let tree = resvg::usvg::Tree::from_data(&svg, &resvg::usvg::Options::default())
+        .unwrap_or_else(|error| panic!("parse {}: {error}", svg_path.display()));
+    let size = tree.size();
+    let scale = 1024.0 / size.width();
+    let width = 1024u32;
+    let height = ((size.height() * scale).round() as u32).max(1);
+    let mut pixmap = resvg::tiny_skia::Pixmap::new(width, height).unwrap_or_else(|| {
+        panic!("allocate empty wallpaper pixmap {width}x{height}");
+    });
+    resvg::render(
+        &tree,
+        resvg::tiny_skia::Transform::from_scale(scale, scale),
+        &mut pixmap.as_mut(),
+    );
+    let rgba_path = out_dir.join("empty_wallpaper.rgba");
+    fs::write(&rgba_path, pixmap.data()).unwrap_or_else(|error| {
+        panic!("write {}: {error}", rgba_path.display());
+    });
+    fs::write(
+        out_dir.join("empty_wallpaper_rgba.rs"),
+        format!(
+            "pub const EMPTY_WALLPAPER_WIDTH: u32 = {width};\n\
+             pub const EMPTY_WALLPAPER_HEIGHT: u32 = {height};\n\
+             pub const EMPTY_WALLPAPER_RGBA: &[u8] = include_bytes!(\"empty_wallpaper.rgba\");\n"
+        ),
+    )
+    .expect("write empty_wallpaper_rgba.rs");
 }
 
 fn compile_layer_shell_shaders(manifest_dir: &Path, out_dir: &Path) {

--- a/data/icons/hicolor/scalable/apps/waywallen.svg
+++ b/data/icons/hicolor/scalable/apps/waywallen.svg
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 1024 1024"
+   width="1024"
+   height="1024"
+   role="img"
+   version="1.1"
+   id="svg_waywallen"
+   sodipodi:docname="waywallen-icon-coral.svg"
+   inkscape:version="1.4.3 (0d15f75042, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs21" />
+  <sodipodi:namedview
+     id="namedview21"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.55864198"
+     inkscape:cx="247.92265"
+     inkscape:cy="643.52486"
+     inkscape:window-width="1920"
+     inkscape:window-height="1018"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg_waywallen" />
+  <title
+     id="waywallen">waywallen — Coral App Icon</title>
+  <desc
+     id="desc1">waywallen wallpaper manager app icon, coral color scheme</desc>
+  <!-- Background: standard iOS/macOS rounded corners ~22.5% -->
+  <rect
+     width="1024"
+     height="1024"
+     rx="230"
+     ry="230"
+     fill="#2A0E07"
+     id="back" />
+  <!--
+    Content scaled 10x, centered at (512,512).
+    Rects span ±410px → 820px wide = 80% of 1024. Good fill.
+
+    RECTS (centered at 0,0):
+      TL: x=-410, y=-410, w=460, h=300, rx=70   (wide short, top-left)
+      TR: x= 110, y=-410, w=300, h=460, rx=70   (narrow tall, top-right)
+      BL: x=-410, y= -50, w=300, h=460, rx=70   (narrow tall, bottom-left)
+      BR: x= -50, y= 110, w=460, h=300, rx=70   (wide short, bottom-right)
+          BR left = -50 = BL.right(-110) + gap(60) ✓
+          BR bottom = 110+300 = 410 = BL.bottom(-50+460=410) ✓
+
+    GEAR shadow (bg color, +40px uniform offset from theme gear):
+      body r=200, tooth: w=150, h=130, anchor_y=-260, rx=35
+    GEAR theme (coral light):
+      body r=160, tooth: w=70,  h=90,  anchor_y=-220, rx=20
+    RINGS:
+      bg    r=110
+      theme r=80
+      center r=40
+  -->
+  <g
+     transform="translate(512,512)"
+     id="g21">
+    <!-- RECTS -->
+    <g
+       id="rect">
+      <rect
+         x="-410"
+         y="-410"
+         width="460"
+         height="300"
+         rx="70"
+         fill="#D85A30"
+         id="rect2" />
+      <rect
+         x="110"
+         y="-410"
+         width="300"
+         height="460"
+         rx="70"
+         fill="#F0997B"
+         id="rect3" />
+      <rect
+         x="-410"
+         y="-50"
+         width="300"
+         height="460"
+         rx="70"
+         fill="#993C1D"
+         id="rect4" />
+      <rect
+         x="-50"
+         y="110"
+         width="460"
+         height="300"
+         rx="70"
+         fill="#993C1D"
+         opacity="0.85"
+         id="rect5" />
+    </g>
+    <!-- GEAR: shadow layer -->
+    <g
+       id="gear_back">
+      <circle
+         cx="0"
+         cy="0"
+         r="200"
+         fill="#2A0E07"
+         id="circle5" />
+      <rect
+         x="-75"
+         y="-260"
+         width="150"
+         height="130"
+         rx="35"
+         fill="#2A0E07"
+         id="rect6"
+         transform="rotate(0)" />
+      <rect
+         x="-75"
+         y="-260"
+         width="150"
+         height="130"
+         rx="35"
+         fill="#2A0E07"
+         transform="rotate(51.43)"
+         id="rect7" />
+      <rect
+         x="-75"
+         y="-260"
+         width="150"
+         height="130"
+         rx="35"
+         fill="#2A0E07"
+         transform="rotate(102.86)"
+         id="rect8" />
+      <rect
+         x="-75"
+         y="-260"
+         width="150"
+         height="130"
+         rx="35"
+         fill="#2A0E07"
+         transform="rotate(154.29)"
+         id="rect9" />
+      <rect
+         x="-75"
+         y="-260"
+         width="150"
+         height="130"
+         rx="35"
+         fill="#2A0E07"
+         transform="rotate(205.71)"
+         id="rect10" />
+      <rect
+         x="-75"
+         y="-260"
+         width="150"
+         height="130"
+         rx="35"
+         fill="#2A0E07"
+         transform="rotate(257.14)"
+         id="rect11" />
+      <rect
+         x="-75"
+         y="-260"
+         width="150"
+         height="130"
+         rx="35"
+         fill="#2A0E07"
+         transform="rotate(308.57)"
+         id="rect12" />
+    </g>
+    <!-- GEAR: theme color -->
+    <g
+       id="gear">
+      <circle
+         cx="0"
+         cy="0"
+         r="160"
+         fill="#F0997B"
+         id="circle12" />
+      <rect
+         x="-35"
+         y="-220"
+         width="70"
+         height="90"
+         rx="20"
+         fill="#F0997B"
+         transform="rotate(0)"
+         id="rect13" />
+      <rect
+         x="-35"
+         y="-220"
+         width="70"
+         height="90"
+         rx="20"
+         fill="#F0997B"
+         transform="rotate(51.43)"
+         id="rect14" />
+      <rect
+         x="-35"
+         y="-220"
+         width="70"
+         height="90"
+         rx="20"
+         fill="#F0997B"
+         transform="rotate(102.86)"
+         id="rect15" />
+      <rect
+         x="-35"
+         y="-220"
+         width="70"
+         height="90"
+         rx="20"
+         fill="#F0997B"
+         transform="rotate(154.29)"
+         id="rect16" />
+      <rect
+         x="-35"
+         y="-220"
+         width="70"
+         height="90"
+         rx="20"
+         fill="#F0997B"
+         transform="rotate(205.71)"
+         id="rect17" />
+      <rect
+         x="-35"
+         y="-220"
+         width="70"
+         height="90"
+         rx="20"
+         fill="#F0997B"
+         transform="rotate(257.14)"
+         id="rect18" />
+      <rect
+         x="-35"
+         y="-220"
+         width="70"
+         height="90"
+         rx="20"
+         fill="#F0997B"
+         transform="rotate(308.57)"
+         id="rect19" />
+    </g>
+    <!-- GEAR: rings -->
+    <g
+       id="rings">
+      <circle
+         cx="0"
+         cy="0"
+         r="110"
+         fill="#2A0E07"
+         id="circle19" />
+      <circle
+         cx="0"
+         cy="0"
+         r="80"
+         fill="#F0997B"
+         id="circle20" />
+      <circle
+         cx="0"
+         cy="0"
+         r="40"
+         fill="#2A0E07"
+         id="circle21" />
+    </g>
+  </g>
+</svg>

--- a/extensions/gnome/CMakeLists.txt
+++ b/extensions/gnome/CMakeLists.txt
@@ -50,6 +50,9 @@ add_custom_target(waywallen-gnome-translations ALL DEPENDS ${_ww_gnome_mo_files}
 
 # --- Component install (cpack zip) ----------------------------------------
 
+set(_ww_icon
+    "${CMAKE_SOURCE_DIR}/data/icons/hicolor/scalable/apps/waywallen.svg")
+
 set(_ext_files
     ${CMAKE_CURRENT_BINARY_DIR}/metadata.json
     extension/extension.js
@@ -65,6 +68,10 @@ set(_ext_files
 )
 
 install(FILES ${_ext_files}
+    DESTINATION "."
+    COMPONENT gnome_extension
+    EXCLUDE_FROM_ALL)
+install(FILES ${_ww_icon}
     DESTINATION "."
     COMPONENT gnome_extension
     EXCLUDE_FROM_ALL)
@@ -130,6 +137,8 @@ install(FILES extension/schemas/${WW_GNOME_SCHEMA_ID}.gschema.xml
     DESTINATION ${CMAKE_INSTALL_DATADIR}/glib-2.0/schemas)
 
 install(FILES ${_ext_files}
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/gnome-shell/extensions/${WW_GNOME_UUID})
+install(FILES ${_ww_icon}
     DESTINATION ${CMAKE_INSTALL_DATADIR}/gnome-shell/extensions/${WW_GNOME_UUID})
 install(FILES extension/schemas/${WW_GNOME_SCHEMA_ID}.gschema.xml
     DESTINATION ${CMAKE_INSTALL_DATADIR}/gnome-shell/extensions/${WW_GNOME_UUID}/schemas)

--- a/extensions/gnome/extension/extension.js
+++ b/extensions/gnome/extension/extension.js
@@ -54,7 +54,7 @@ export default class WaywallenExtension extends Extension {
             this._settings.apply();
         }
 
-        this._override = new GnomeShellOverride(this._settings);
+        this._override = new GnomeShellOverride(this._settings, this.path);
 
         // Defer renderer spawn + override install until shell startup
         // animation is past, so we don't fight Main.layoutManager's

--- a/extensions/gnome/extension/gnomeShellOverride.js
+++ b/extensions/gnome/extension/gnomeShellOverride.js
@@ -16,9 +16,10 @@ import {PauseEffectKind} from './controlCodec.js';
 const APPLICATION_ID = Wallpaper.APPLICATION_ID;
 
 export class GnomeShellOverride {
-    constructor(settings) {
+    constructor(settings, extensionPath = '') {
         this._injection = new InjectionManager();
         this._settings = settings;
+        this._extensionPath = extensionPath;
         // Held by LiveWallpaper -> nothing; we only iterate on disable
         // and let Clutter destruction cascades clean up otherwise.
         // Using a Set (not Map) means we don't need to wire a destroy
@@ -43,7 +44,8 @@ export class GnomeShellOverride {
                     ? Wallpaper.WallpaperRole.Desktop
                     : Wallpaper.WallpaperRole.Other;
                 this.waywallenActor = new Wallpaper.LiveWallpaper(
-                    backgroundActor, role, self._rendererAvailable, self._rendererLauncher);
+                    backgroundActor, role, self._rendererAvailable, self._rendererLauncher,
+                    self._extensionPath);
                 self._wallpaperActors.add(this.waywallenActor);
                 if (role === Wallpaper.WallpaperRole.Desktop)
                     self._applyPresentationToActor(this.waywallenActor);

--- a/extensions/gnome/extension/wallpaper.js
+++ b/extensions/gnome/extension/wallpaper.js
@@ -4,6 +4,7 @@
 // corners (in workspace overview) and lifetime automatically.
 
 import Clutter from 'gi://Clutter';
+import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 import St from 'gi://St';
@@ -20,16 +21,24 @@ export const WallpaperRole = Object.freeze({
     Other: 'other',
 });
 
-export function rendererPresentationReady(actor) {
+export function rendererTitleHint(actor) {
     const title = actor?.meta_window?.title;
     if (!title?.startsWith(TITLE_PREFIX))
-        return false;
+        return null;
     const payload = title.slice(TITLE_PREFIX.length).split('|', 1)[0];
     try {
-        return JSON.parse(payload).presentationReady === true;
+        return JSON.parse(payload);
     } catch (_e) {
-        return false;
+        return null;
     }
+}
+
+export function rendererPresentationReady(actor) {
+    return rendererTitleHint(actor)?.presentationReady === true;
+}
+
+export function rendererHasFrame(actor) {
+    return rendererTitleHint(actor)?.hasFrame === true;
 }
 
 const FADE_IN_MS = 800;
@@ -37,7 +46,7 @@ const FADE_IN_MS = 800;
 export const LiveWallpaper = GObject.registerClass(
 class LiveWallpaper extends St.Widget {
     _init(backgroundActor, role = WallpaperRole.Other, rendererAvailable = false,
-        rendererLauncher = null) {
+        rendererLauncher = null, extensionPath = '') {
         super._init({
             // FixedLayout: we position the clone ourselves in vfunc_allocate
             // (top-left origin, scaled to fill). BinLayout centered the
@@ -69,9 +78,15 @@ class LiveWallpaper extends St.Widget {
         this._sourceActor = null;
         this._sourceDestroyId = 0;
         this._pollId = 0;
+        this._placeholder = null;
+        this._placeholderIcon = null;
+        this._extensionPath = extensionPath;
+        this._titleNotifyId = 0;
         if (this._role === WallpaperRole.Desktop)
-            this.set_style('background-color: black;');
+            this.set_style('background-color: #D85A30;');
+        this._ensurePlaceholder();
         this._tryAttach();
+        this._syncPlaceholder();
     }
 
     // Report no preferred size: the clone's natural (monitor) size would
@@ -100,6 +115,23 @@ class LiveWallpaper extends St.Widget {
                 Math.abs((clone.scale_y ?? 1) - sy) > 0.001)
                 clone.set_scale(sx, sy);
         }
+        const placeholder = this._placeholder;
+        if (placeholder && placeholder.visible) {
+            const iconSize = Math.max(64,
+                Math.round(Math.min(box.get_width(), box.get_height()) * 0.22));
+            if (this._placeholderIcon && this._placeholderIcon.icon_size !== iconSize)
+                this._placeholderIcon.icon_size = iconSize;
+            const [, natWidth] = placeholder.get_preferred_width(-1);
+            const [, natHeight] = placeholder.get_preferred_height(-1);
+            const x = Math.round((box.get_width() - natWidth) / 2);
+            const y = Math.round((box.get_height() - natHeight) / 2);
+            placeholder.allocate(new Clutter.ActorBox({
+                x1: x,
+                y1: y,
+                x2: x + natWidth,
+                y2: y + natHeight,
+            }));
+        }
     }
 
     _tryAttach() {
@@ -121,6 +153,7 @@ class LiveWallpaper extends St.Widget {
             this._sourceDestroyId = renderer.connect('destroy',
                 () => this._onSourceDestroyed());
             this.add_child(this._cloneActor);
+            this._connectTitleNotify(renderer);
             if (this._role === WallpaperRole.Desktop) {
                 this._blurController = new BlurController(
                     this._cloneActor, 'waywallen-desktop-blur');
@@ -134,10 +167,10 @@ class LiveWallpaper extends St.Widget {
             });
             // Black out the gsettings placeholder behind us (see _dimBackdrop).
             this._dimBackdrop(true);
-            // No redraw timer: Clutter.Clone repaints on the source's
-            // queue-redraw, i.e. exactly when the renderer commits a buffer.
+            this._syncPlaceholder();
             return;
         }
+        this._syncPlaceholder();
         this._schedulePoll();
     }
 
@@ -176,6 +209,7 @@ class LiveWallpaper extends St.Widget {
     }
 
     _onSourceDestroyed() {
+        this._disconnectTitleNotify();
         this._sourceDestroyId = 0;
         this._sourceActor = null;
         this._blurController?.destroy();
@@ -200,10 +234,82 @@ class LiveWallpaper extends St.Widget {
         if (this._role === WallpaperRole.Desktop) {
             this.opacity = 255;
             this._dimBackdrop(true);
+            this._showPlaceholder(true);
         } else {
             this.opacity = 0;
             this._dimBackdrop(false);
+            this._showPlaceholder(false);
         }
+    }
+
+    _ensurePlaceholder() {
+        if (this._placeholder || this._role !== WallpaperRole.Desktop)
+            return;
+        const iconPath = GLib.build_filenamev([this._extensionPath, 'waywallen.svg']);
+        const box = new St.BoxLayout({
+            vertical: true,
+            x_expand: false,
+            y_expand: false,
+            style: 'spacing: 12px;',
+        });
+        const file = Gio.File.new_for_path(iconPath);
+        if (file.query_exists(null)) {
+            this._placeholderIcon = new St.Icon({
+                gicon: new Gio.FileIcon({file}),
+                icon_size: 128,
+                x_align: Clutter.ActorAlign.CENTER,
+            });
+            box.add_child(this._placeholderIcon);
+        }
+        box.add_child(new St.Label({
+            text: 'No wallpaper selected',
+            x_align: Clutter.ActorAlign.CENTER,
+            style: 'color: white; font-size: 22px; font-weight: 600;',
+        }));
+        box.add_child(new St.Label({
+            text: 'Open Waywallen and select a wallpaper.',
+            x_align: Clutter.ActorAlign.CENTER,
+            style: 'color: #cdd6f4; font-size: 16px;',
+        }));
+        box.visible = false;
+        this.add_child(box);
+        this._placeholder = box;
+    }
+
+    _connectTitleNotify(renderer) {
+        this._disconnectTitleNotify();
+        const win = renderer?.meta_window;
+        if (!win)
+            return;
+        this._titleNotifyId = win.connect('notify::title', () => this._syncPlaceholder());
+    }
+
+    _disconnectTitleNotify() {
+        const win = this._sourceActor?.meta_window;
+        if (win && this._titleNotifyId) {
+            try { win.disconnect(this._titleNotifyId); } catch (_e) {}
+        }
+        this._titleNotifyId = 0;
+    }
+
+    _syncPlaceholder() {
+        if (this._role !== WallpaperRole.Desktop) {
+            this._showPlaceholder(false);
+            return;
+        }
+        const show = !this._cloneActor || !rendererHasFrame(this._sourceActor);
+        this._showPlaceholder(show);
+        if (show && this._placeholder && this._cloneActor)
+            this._placeholder.raise_top();
+    }
+
+    _showPlaceholder(show) {
+        this._ensurePlaceholder();
+        if (!this._placeholder)
+            return;
+        this._placeholder.visible = show;
+        if (show)
+            this.queue_relayout();
     }
 
     setRendererAvailable(available) {
@@ -221,6 +327,7 @@ class LiveWallpaper extends St.Widget {
                 duration: FADE_IN_MS,
                 mode: Clutter.AnimationMode.EASE_OUT_QUAD,
             });
+            this._syncPlaceholder();
             return;
         }
         this._tryAttach();
@@ -290,6 +397,7 @@ class LiveWallpaper extends St.Widget {
         if (this._sourceActor && this._sourceDestroyId) {
             try { this._sourceActor.disconnect(this._sourceDestroyId); } catch (_e) {}
         }
+        this._disconnectTitleNotify();
         this._sourceActor = null;
         this._sourceDestroyId = 0;
         this._blurController?.destroy();
@@ -299,6 +407,8 @@ class LiveWallpaper extends St.Widget {
             this._cloneDestroyId = 0;
         }
         this._cloneActor = null;
+        this._placeholder = null;
+        this._placeholderIcon = null;
         this._dimBackdrop(false);
         super.on_destroy?.();
     }

--- a/extensions/gnome/renderer/renderer.js
+++ b/extensions/gnome/renderer/renderer.js
@@ -127,6 +127,7 @@ class MonitorRenderer {
         this._destroyed = false;
         this._presentation = null;
         this._presentationReady = false;
+        this._hasFrame = false;
     }
 
     build(app) {
@@ -378,6 +379,10 @@ class MonitorRenderer {
             Waywallen.Display.close_fd(fd);
         this._frames = (this._frames ?? 0) + 1;
         this._paintable?.refresh();
+        if (!this._hasFrame) {
+            this._hasFrame = true;
+            this._updateWindowTitle();
+        }
     }
 
     _controlGeometry() {
@@ -452,6 +457,7 @@ class MonitorRenderer {
             keepPosition: true,
             position: [geometry.x, geometry.y],
             presentationReady: this._presentationReady,
+            hasFrame: this._hasFrame,
         });
         this._window.set_title(`@${APP_ID}!${hint}|${this._index}`);
     }

--- a/extensions/kde/package/contents/ui/main.qml
+++ b/extensions/kde/package/contents/ui/main.qml
@@ -23,7 +23,55 @@ WallpaperItem {
     // daemon doesn't flash the desktop wallpaper through.
     Rectangle {
         anchors.fill: parent
-        color: "black"
+        color: emptyPlaceholder.visible ? "#D85A30" : "black"
+    }
+
+    // Shown when there is nothing to present: first run, or the daemon
+    // has gone away (quit / crash). Connected idle with a last frame
+    // keeps that frame — overlay stays off.
+    Column {
+        id: emptyPlaceholder
+        anchors.centerIn: parent
+        spacing: Kirigami.Units.largeSpacing
+        width: Math.min(parent.width, parent.height) * 0.5
+        visible: {
+            if (surfaceLoader.status === Loader.Error)
+                return false;
+            const d = surfaceLoader.item ? surfaceLoader.item.display : null;
+            if (!d)
+                return true;
+            // WaywallenDisplay::ConnState::Connected == 3
+            return d.framesReceived === 0 || d.connState !== 3;
+        }
+
+        Image {
+            anchors.horizontalCenter: parent.horizontalCenter
+            width: Math.min(root.width, root.height) * 0.22
+            height: width
+            fillMode: Image.PreserveAspectFit
+            source: Qt.resolvedUrl("../images/waywallen.svg")
+            sourceSize.width: width * Screen.devicePixelRatio
+            sourceSize.height: height * Screen.devicePixelRatio
+        }
+        Text {
+            anchors.horizontalCenter: parent.horizontalCenter
+            width: parent.width
+            color: "white"
+            font.pixelSize: 22
+            font.weight: Font.DemiBold
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+            text: "No wallpaper selected"
+        }
+        Text {
+            anchors.horizontalCenter: parent.horizontalCenter
+            width: parent.width
+            color: "#cdd6f4"
+            font.pixelSize: 16
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+            text: "Open Waywallen and select a wallpaper."
+        }
     }
 
     property bool _initDone: false

--- a/plugins/gobject/CMakeLists.txt
+++ b/plugins/gobject/CMakeLists.txt
@@ -39,6 +39,16 @@ target_compile_options(waywallen-gobject PRIVATE -Wall -Wextra)
 
 find_program(G_IR_SCANNER g-ir-scanner)
 find_program(G_IR_COMPILER g-ir-compiler)
+# g-ir-scanner's shebang is `#!/usr/bin/env python3`. If conda/miniconda is
+# first on PATH, that python cannot import the distro giscanner._giscanner
+# (built for the system ABI). Drive the scanner with /usr/bin/python3 when
+# it exists.
+find_program(WW_SYSTEM_PYTHON3 python3 PATHS /usr/bin NO_DEFAULT_PATH)
+if(WW_SYSTEM_PYTHON3)
+    set(WW_GIR_SCANNER ${WW_SYSTEM_PYTHON3} ${G_IR_SCANNER})
+else()
+    set(WW_GIR_SCANNER ${G_IR_SCANNER})
+endif()
 
 if(G_IR_SCANNER AND G_IR_COMPILER)
     set(WW_GIR_NAMESPACE "Waywallen")
@@ -52,7 +62,7 @@ if(G_IR_SCANNER AND G_IR_COMPILER)
 
     add_custom_command(
         OUTPUT  ${WW_GIR_FILE}
-        COMMAND ${G_IR_SCANNER}
+        COMMAND ${WW_GIR_SCANNER}
                 --warn-all
                 --no-libtool
                 --namespace=${WW_GIR_NAMESPACE}

--- a/plugins/gobject/ww-shadow-paintable.c
+++ b/plugins/gobject/ww-shadow-paintable.c
@@ -130,8 +130,9 @@ static void snapshot_vfunc(GdkPaintable* paintable, GdkSnapshot* snapshot, doubl
     if (! isfinite(height) || height <= 0.0) height = self->height ? (double)self->height : 0.0;
     if (width <= 0.0 || height <= 0.0) return;
 
-    /* Clear-color base (default opaque black): pre-content + letterbox
-     * background, else the GTK window background leaks through. */
+    /* Clear-color base (empty wallpaper #D85A30, then daemon letterbox):
+     * pre-content + letterbox background, else the GTK window background
+     * leaks through. */
     if (self->clear[3] > 0.0f) {
         GdkRGBA         bg = { self->clear[0], self->clear[1], self->clear[2], self->clear[3] };
         graphene_rect_t full;
@@ -195,12 +196,18 @@ static void ww_shadow_paintable_iface_init(GdkPaintableInterface* iface) {
     iface->get_intrinsic_aspect_ratio = intrinsic_aspect_vfunc;
 }
 
+static void ww_empty_wallpaper_clear(float clear[4]) {
+    /* #D85A30 — fill used before any producer frame. */
+    clear[0] = 216.0f / 255.0f;
+    clear[1] = 90.0f / 255.0f;
+    clear[2] = 48.0f / 255.0f;
+    clear[3] = 1.0f;
+}
+
 static void ww_shadow_paintable_init(WwShadowPaintable* self) {
     self->fd = -1;
-    /* Default letterbox / pre-content background: opaque black. The
-     * daemon overrides via composition config; this is what shows before any
-     * content and behind a partial-coverage fill mode. */
-    self->clear[3] = 1.0f;
+    /* Daemon overrides via composition config once a stream is bound. */
+    ww_empty_wallpaper_clear(self->clear);
 }
 
 static void ww_shadow_paintable_finalize(GObject* object) {
@@ -301,9 +308,6 @@ void ww_shadow_paintable_clear(WwShadowPaintable* self) {
     memset(self->src, 0, sizeof(self->src));
     memset(self->dst, 0, sizeof(self->dst));
     self->transform = 0;
-    self->clear[0]  = 0.0f;
-    self->clear[1]  = 0.0f;
-    self->clear[2]  = 0.0f;
-    self->clear[3]  = 1.0f;
+    ww_empty_wallpaper_clear(self->clear);
     gdk_paintable_invalidate_contents(GDK_PAINTABLE(self));
 }

--- a/plugins/gobject/ww-shadow-paintable.h
+++ b/plugins/gobject/ww-shadow-paintable.h
@@ -88,7 +88,7 @@ void ww_shadow_paintable_set_composition(WwShadowPaintable* self, double sx, dou
  * @self: a #WwShadowPaintable
  *
  * Release the texture + shadow fd and discard the connection-local
- * composition. The paintable renders opaque black until the next
+ * composition. The paintable fills #D85A30 until the next
  * set_shadow() and set_composition().
  */
 void ww_shadow_paintable_clear(WwShadowPaintable* self);

--- a/src/bin/layer_shell/main.rs
+++ b/src/bin/layer_shell/main.rs
@@ -452,7 +452,7 @@ impl App {
         if matches!(session.state, DisplaySessionState::Retiring { .. }) {
             if let Some(binding) = entry.binding.as_ref() {
                 log::warn!(
-                    "[{}] black fallback presentation failed: {error:#}",
+                    "[{}] empty wallpaper presentation failed: {error:#}",
                     binding.display_name
                 );
                 binding.pending_present.store(false, Ordering::SeqCst);
@@ -486,7 +486,7 @@ impl App {
                 binding.pending_present.store(true, Ordering::SeqCst);
             }
             if requested {
-                log::info!("[{}] black fallback requested", binding.display_name);
+                log::info!("[{}] empty wallpaper requested", binding.display_name);
             }
         }
         session.state = DisplaySessionState::Retiring {
@@ -1009,7 +1009,7 @@ fn make_output_binding(
         "output {output_name}: identity '{}' -> instance_id={instance_id}",
         output_identity_key(entry, output_name)
     );
-    Rc::new(OutputBinding {
+    let binding = Rc::new(OutputBinding {
         display_name,
         instance_id,
         configured_size: Mutex::new(Some(physical)),
@@ -1022,10 +1022,13 @@ fn make_output_binding(
         config: Mutex::new(FrameConfig::default()),
         runtime,
         presenter: Mutex::new(presenter),
-        pending_present: AtomicBool::new(false),
+        pending_present: AtomicBool::new(true),
         next_redraw: Mutex::new(None),
         watcher,
-    })
+    });
+    binding.presenter.lock().unwrap().request_blank();
+    log::info!("[{}] empty wallpaper requested", binding.display_name);
+    binding
 }
 
 fn logical_to_physical(state: &App, output_name: u32, lx: f64, ly: f64) -> (f32, f32) {
@@ -2097,20 +2100,19 @@ fn present_latest(binding: &OutputBinding) -> Result<()> {
         .lock()
         .unwrap()
         .as_ref()
-        .ok_or_else(|| anyhow!("present requested without a display session"))?
-        .0;
-    let release_display = (unsafe { sys::waywallen_display_conn_state(display) }
-        == sys::WAYWALLEN_CONN_CONNECTED)
-        .then_some(display);
+        .map(|display| display.0);
+    let release_display = display.filter(|&display| unsafe {
+        sys::waywallen_display_conn_state(display) == sys::WAYWALLEN_CONN_CONNECTED
+    });
     let mut presenter = binding.presenter.lock().unwrap();
     let was_blank = presenter.blank_committed();
     match presenter.present(release_display, &composition, Instant::now())? {
         vulkan::PresentResult::Presented { redraw } => {
             if !was_blank && presenter.blank_committed() {
-                log::info!("[{}] black fallback committed", binding.display_name);
+                log::info!("[{}] empty wallpaper committed", binding.display_name);
             } else if was_blank && !presenter.blank_committed() {
                 log::info!(
-                    "[{}] first frame replaced black fallback",
+                    "[{}] first frame replaced empty wallpaper",
                     binding.display_name
                 );
             }

--- a/src/bin/layer_shell/vulkan.rs
+++ b/src/bin/layer_shell/vulkan.rs
@@ -19,10 +19,18 @@ const TOTAL_PUSH_CONSTANT_SIZE: u32 = BLUR_PUSH_CONSTANT_OFFSET + BLUR_PUSH_CONS
 const RESOURCE_RETIRE_TIMEOUT_NS: u64 = 2_000_000_000;
 const SWAPCHAIN_ACQUIRE_TIMEOUT_NS: u64 = 1_000_000;
 const BLUR_TRANSITION_DURATION: Duration = Duration::from_millis(180);
+// Empty-wallpaper fill (#D85A30).
+const EMPTY_WALLPAPER_CLEAR: [f32; 4] = [
+    0xD8 as f32 / 255.0,
+    0x5A as f32 / 255.0,
+    0x30 as f32 / 255.0,
+    1.0,
+];
 const _: () = assert!(COMPOSITION_PUSH_CONSTANT_SIZE == 48);
 const _: () = assert!(TOTAL_PUSH_CONSTANT_SIZE <= 128);
 
 include!(concat!(env!("OUT_DIR"), "/layer_shell_shaders.rs"));
+include!(concat!(env!("OUT_DIR"), "/empty_wallpaper_rgba.rs"));
 
 #[repr(C)]
 struct CompositionPushConstants {
@@ -682,6 +690,13 @@ enum BlankState {
     Committed,
 }
 
+struct PlaceholderTexture {
+    image: vk::Image,
+    memory: vk::DeviceMemory,
+    view: vk::ImageView,
+    extent: vk::Extent2D,
+}
+
 impl BlankState {
     fn request(&mut self) -> bool {
         if *self != Self::Inactive {
@@ -736,6 +751,7 @@ pub struct WsiPresenter {
     direct_binding: Option<DirectBinding>,
     pending_direct_frame: Option<DirectFrame>,
     blank_state: BlankState,
+    placeholder: Option<PlaceholderTexture>,
     recreate_extent: Option<vk::Extent2D>,
     retired_swapchains: Vec<RetiredSwapchain>,
 }
@@ -777,6 +793,7 @@ impl WsiPresenter {
             direct_binding: None,
             pending_direct_frame: None,
             blank_state: BlankState::Inactive,
+            placeholder: None,
             recreate_extent: None,
             retired_swapchains: Vec::new(),
         };
@@ -901,6 +918,13 @@ impl WsiPresenter {
             width: extent.0,
             height: extent.1,
         })?;
+        self.placeholder = match self.create_placeholder_texture() {
+            Ok(texture) => Some(texture),
+            Err(error) => {
+                log::warn!("empty wallpaper texture unavailable: {error:#}");
+                None
+            }
+        };
         Ok(())
     }
 
@@ -1141,10 +1165,8 @@ impl WsiPresenter {
             swapchain_recreated = true;
         }
 
-        let blank_pending = self.blank_state == BlankState::Pending;
-        let pending_direct = (!blank_pending)
-            .then(|| self.pending_direct_frame.as_ref().map(direct_frame_handles))
-            .flatten();
+        let pending_direct = self.pending_direct_frame.as_ref().map(direct_frame_handles);
+        let blank_pending = self.blank_state == BlankState::Pending && pending_direct.is_none();
         if scene_path && pending_direct.is_some() {
             let extent_mismatch = self
                 .blur_resources
@@ -1237,7 +1259,13 @@ impl WsiPresenter {
         }
         .context("reset WSI command pool")?;
 
-        let source_info = pending_direct.map(|(_, view, _, _, _, _)| {
+        let placeholder_view = blank_pending
+            .then(|| self.placeholder.as_ref().map(|texture| texture.view))
+            .flatten();
+        let source_view = pending_direct
+            .map(|(_, view, _, _, _, _)| view)
+            .or(placeholder_view);
+        let source_info = source_view.map(|view| {
             [vk::DescriptorImageInfo::default()
                 .sampler(self.sampler)
                 .image_view(view)
@@ -1261,7 +1289,7 @@ impl WsiPresenter {
         }
         .context("vkBeginCommandBuffer")?;
         let clear_color = if blank_pending {
-            [0.0, 0.0, 0.0, 1.0]
+            EMPTY_WALLPAPER_CLEAR
         } else {
             composition.clear
         };
@@ -1274,14 +1302,39 @@ impl WsiPresenter {
             offset: vk::Offset2D { x: 0, y: 0 },
             extent: self.extent,
         };
-        let composition_push = pending_direct.map(|(_, _, source_extent, _, _, _)| {
+        let composition_push = if let Some((_, _, source_extent, _, _, _)) = pending_direct {
             let output_extent = if scene_path {
                 self.blur_resources.as_ref().unwrap().extent
             } else {
                 self.extent
             };
-            composition_push_constants(composition, output_extent, source_extent)
-        });
+            Some(composition_push_constants(
+                composition,
+                output_extent,
+                source_extent,
+            ))
+        } else if blank_pending {
+            self.placeholder.as_ref().map(|texture| {
+                let dest = placeholder_destination(self.extent, texture.extent);
+                composition_push_constants(
+                    &Composition {
+                        source: [
+                            0.0,
+                            0.0,
+                            texture.extent.width as f32,
+                            texture.extent.height as f32,
+                        ],
+                        destination: dest,
+                        transform: 0,
+                        clear: EMPTY_WALLPAPER_CLEAR,
+                    },
+                    self.extent,
+                    texture.extent,
+                )
+            })
+        } else {
+            None
+        };
         let composition_push_bytes = composition_push.as_ref().map(|push| unsafe {
             std::slice::from_raw_parts(
                 std::ptr::from_ref(push).cast::<u8>(),
@@ -1961,6 +2014,312 @@ impl WsiPresenter {
             })
     }
 
+    fn create_placeholder_texture(&self) -> Result<PlaceholderTexture> {
+        const PIXEL_BYTES: u64 = 4;
+        let extent = vk::Extent2D {
+            width: EMPTY_WALLPAPER_WIDTH,
+            height: EMPTY_WALLPAPER_HEIGHT,
+        };
+        let pixel_count = (extent.width as u64)
+            .checked_mul(extent.height as u64)
+            .and_then(|pixels| pixels.checked_mul(PIXEL_BYTES))
+            .ok_or_else(|| anyhow!("empty wallpaper dimensions overflow"))?;
+        if EMPTY_WALLPAPER_RGBA.len() as u64 != pixel_count {
+            bail!(
+                "empty wallpaper rgba len {} does not match {pixel_count}",
+                EMPTY_WALLPAPER_RGBA.len()
+            );
+        }
+        let device = &self.runtime.device;
+        let image_info = vk::ImageCreateInfo::default()
+            .image_type(vk::ImageType::TYPE_2D)
+            .format(vk::Format::R8G8B8A8_UNORM)
+            .extent(vk::Extent3D {
+                width: extent.width,
+                height: extent.height,
+                depth: 1,
+            })
+            .mip_levels(1)
+            .array_layers(1)
+            .samples(vk::SampleCountFlags::TYPE_1)
+            .tiling(vk::ImageTiling::OPTIMAL)
+            .usage(vk::ImageUsageFlags::TRANSFER_DST | vk::ImageUsageFlags::SAMPLED)
+            .sharing_mode(vk::SharingMode::EXCLUSIVE)
+            .initial_layout(vk::ImageLayout::UNDEFINED);
+        let image = unsafe { device.create_image(&image_info, None) }
+            .context("create empty wallpaper image")?;
+        let requirements = unsafe { device.get_image_memory_requirements(image) };
+        let memory_type = self
+            .find_memory_type(
+                requirements.memory_type_bits,
+                vk::MemoryPropertyFlags::DEVICE_LOCAL,
+            )
+            .ok_or_else(|| anyhow!("no device-local memory for empty wallpaper image"))?;
+        let allocate = vk::MemoryAllocateInfo::default()
+            .allocation_size(requirements.size)
+            .memory_type_index(memory_type);
+        let memory = unsafe { device.allocate_memory(&allocate, None) }.map_err(|error| {
+            unsafe { device.destroy_image(image, None) };
+            anyhow!("allocate empty wallpaper image: {error:?}")
+        })?;
+        if let Err(error) = unsafe { device.bind_image_memory(image, memory, 0) } {
+            unsafe {
+                device.free_memory(memory, None);
+                device.destroy_image(image, None);
+            }
+            return Err(anyhow!("bind empty wallpaper image: {error:?}"));
+        }
+
+        let buffer_info = vk::BufferCreateInfo::default()
+            .size(pixel_count)
+            .usage(vk::BufferUsageFlags::TRANSFER_SRC)
+            .sharing_mode(vk::SharingMode::EXCLUSIVE);
+        let staging = unsafe { device.create_buffer(&buffer_info, None) }.map_err(|error| {
+            unsafe {
+                device.free_memory(memory, None);
+                device.destroy_image(image, None);
+            }
+            anyhow!("create empty wallpaper staging buffer: {error:?}")
+        })?;
+        let staging_reqs = unsafe { device.get_buffer_memory_requirements(staging) };
+        let staging_type = self
+            .find_memory_type(
+                staging_reqs.memory_type_bits,
+                vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT,
+            )
+            .ok_or_else(|| anyhow!("no host-visible memory for empty wallpaper staging"))?;
+        let staging_alloc = vk::MemoryAllocateInfo::default()
+            .allocation_size(staging_reqs.size)
+            .memory_type_index(staging_type);
+        let staging_memory = match unsafe { device.allocate_memory(&staging_alloc, None) } {
+            Ok(staging_memory) => staging_memory,
+            Err(error) => {
+                unsafe {
+                    device.destroy_buffer(staging, None);
+                    device.free_memory(memory, None);
+                    device.destroy_image(image, None);
+                }
+                return Err(anyhow!("allocate empty wallpaper staging: {error:?}"));
+            }
+        };
+        if let Err(error) = unsafe { device.bind_buffer_memory(staging, staging_memory, 0) } {
+            unsafe {
+                device.free_memory(staging_memory, None);
+                device.destroy_buffer(staging, None);
+                device.free_memory(memory, None);
+                device.destroy_image(image, None);
+            }
+            return Err(anyhow!("bind empty wallpaper staging: {error:?}"));
+        }
+        let mapped = match unsafe {
+            device.map_memory(staging_memory, 0, pixel_count, vk::MemoryMapFlags::empty())
+        } {
+            Ok(mapped) => mapped,
+            Err(error) => {
+                unsafe {
+                    device.free_memory(staging_memory, None);
+                    device.destroy_buffer(staging, None);
+                    device.free_memory(memory, None);
+                    device.destroy_image(image, None);
+                }
+                return Err(anyhow!("map empty wallpaper staging: {error:?}"));
+            }
+        };
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                EMPTY_WALLPAPER_RGBA.as_ptr(),
+                mapped.cast::<u8>(),
+                EMPTY_WALLPAPER_RGBA.len(),
+            );
+            device.unmap_memory(staging_memory);
+        }
+
+        let pool_info = vk::CommandPoolCreateInfo::default()
+            .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+            .queue_family_index(self.runtime.graphics_queue_family);
+        let command_pool =
+            unsafe { device.create_command_pool(&pool_info, None) }.map_err(|error| {
+                unsafe {
+                    device.free_memory(staging_memory, None);
+                    device.destroy_buffer(staging, None);
+                    device.free_memory(memory, None);
+                    device.destroy_image(image, None);
+                }
+                anyhow!("create empty wallpaper command pool: {error:?}")
+            })?;
+        let command_info = vk::CommandBufferAllocateInfo::default()
+            .command_pool(command_pool)
+            .level(vk::CommandBufferLevel::PRIMARY)
+            .command_buffer_count(1);
+        let command_buffer = match unsafe { device.allocate_command_buffers(&command_info) } {
+            Ok(buffers) => buffers[0],
+            Err(error) => {
+                unsafe {
+                    device.destroy_command_pool(command_pool, None);
+                    device.free_memory(staging_memory, None);
+                    device.destroy_buffer(staging, None);
+                    device.free_memory(memory, None);
+                    device.destroy_image(image, None);
+                }
+                return Err(anyhow!(
+                    "allocate empty wallpaper command buffer: {error:?}"
+                ));
+            }
+        };
+        let begin = vk::CommandBufferBeginInfo::default()
+            .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
+        let record = (|| -> Result<()> {
+            unsafe { device.begin_command_buffer(command_buffer, &begin) }
+                .context("begin empty wallpaper upload")?;
+            let range = full_color_range();
+            let to_transfer = [vk::ImageMemoryBarrier::default()
+                .src_access_mask(vk::AccessFlags::empty())
+                .dst_access_mask(vk::AccessFlags::TRANSFER_WRITE)
+                .old_layout(vk::ImageLayout::UNDEFINED)
+                .new_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+                .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                .image(image)
+                .subresource_range(range)];
+            unsafe {
+                device.cmd_pipeline_barrier(
+                    command_buffer,
+                    vk::PipelineStageFlags::TOP_OF_PIPE,
+                    vk::PipelineStageFlags::TRANSFER,
+                    vk::DependencyFlags::empty(),
+                    &[],
+                    &[],
+                    &to_transfer,
+                );
+            }
+            let copy = [vk::BufferImageCopy::default()
+                .image_subresource(vk::ImageSubresourceLayers {
+                    aspect_mask: vk::ImageAspectFlags::COLOR,
+                    mip_level: 0,
+                    base_array_layer: 0,
+                    layer_count: 1,
+                })
+                .image_extent(vk::Extent3D {
+                    width: extent.width,
+                    height: extent.height,
+                    depth: 1,
+                })];
+            unsafe {
+                device.cmd_copy_buffer_to_image(
+                    command_buffer,
+                    staging,
+                    image,
+                    vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+                    &copy,
+                );
+            }
+            let to_shader = [vk::ImageMemoryBarrier::default()
+                .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
+                .dst_access_mask(vk::AccessFlags::SHADER_READ)
+                .old_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+                .new_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)
+                .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                .image(image)
+                .subresource_range(range)];
+            unsafe {
+                device.cmd_pipeline_barrier(
+                    command_buffer,
+                    vk::PipelineStageFlags::TRANSFER,
+                    vk::PipelineStageFlags::FRAGMENT_SHADER,
+                    vk::DependencyFlags::empty(),
+                    &[],
+                    &[],
+                    &to_shader,
+                );
+            }
+            unsafe { device.end_command_buffer(command_buffer) }
+                .context("end empty wallpaper upload")?;
+            Ok(())
+        })();
+        if let Err(error) = record {
+            unsafe {
+                device.destroy_command_pool(command_pool, None);
+                device.free_memory(staging_memory, None);
+                device.destroy_buffer(staging, None);
+                device.free_memory(memory, None);
+                device.destroy_image(image, None);
+            }
+            return Err(error);
+        }
+        let fence_info = vk::FenceCreateInfo::default();
+        let fence = match unsafe { device.create_fence(&fence_info, None) } {
+            Ok(fence) => fence,
+            Err(error) => {
+                unsafe {
+                    device.destroy_command_pool(command_pool, None);
+                    device.free_memory(staging_memory, None);
+                    device.destroy_buffer(staging, None);
+                    device.free_memory(memory, None);
+                    device.destroy_image(image, None);
+                }
+                return Err(anyhow!("create empty wallpaper fence: {error:?}"));
+            }
+        };
+        let command_buffers = [command_buffer];
+        let submit = [vk::SubmitInfo::default().command_buffers(&command_buffers)];
+        let submitted = unsafe { device.queue_submit(self.runtime.graphics_queue, &submit, fence) };
+        let waited = submitted.and_then(|_| unsafe {
+            device.wait_for_fences(&[fence], true, RESOURCE_RETIRE_TIMEOUT_NS)
+        });
+        unsafe { device.destroy_fence(fence, None) };
+        unsafe { device.destroy_command_pool(command_pool, None) };
+        unsafe {
+            device.free_memory(staging_memory, None);
+            device.destroy_buffer(staging, None);
+        }
+        if let Err(error) = waited {
+            unsafe {
+                device.free_memory(memory, None);
+                device.destroy_image(image, None);
+            }
+            return Err(anyhow!("upload empty wallpaper: {error:?}"));
+        }
+
+        let view_info = vk::ImageViewCreateInfo::default()
+            .image(image)
+            .view_type(vk::ImageViewType::TYPE_2D)
+            .format(vk::Format::R8G8B8A8_UNORM)
+            .subresource_range(full_color_range());
+        let view = match unsafe { device.create_image_view(&view_info, None) } {
+            Ok(view) => view,
+            Err(error) => {
+                unsafe {
+                    device.free_memory(memory, None);
+                    device.destroy_image(image, None);
+                }
+                return Err(anyhow!("create empty wallpaper view: {error:?}"));
+            }
+        };
+        Ok(PlaceholderTexture {
+            image,
+            memory,
+            view,
+            extent,
+        })
+    }
+
+    fn destroy_placeholder(&mut self) {
+        if let Some(texture) = self.placeholder.take() {
+            unsafe {
+                if texture.view != vk::ImageView::null() {
+                    self.runtime.device.destroy_image_view(texture.view, None);
+                }
+                if texture.image != vk::Image::null() {
+                    self.runtime.device.destroy_image(texture.image, None);
+                }
+                if texture.memory != vk::DeviceMemory::null() {
+                    self.runtime.device.free_memory(texture.memory, None);
+                }
+            }
+        }
+    }
+
     fn create_blur_resources(
         &self,
         swapchain_render_pass: vk::RenderPass,
@@ -2495,6 +2854,7 @@ impl Drop for WsiPresenter {
         unsafe {
             let _ = self.runtime.device.device_wait_idle();
         }
+        self.destroy_placeholder();
         if let Some(direct) = self.pending_direct_frame.take() {
             unsafe { libc::close(direct.release_syncobj_fd) };
         }
@@ -2821,6 +3181,20 @@ fn forward_display(transform: u32, pre_u: f32, pre_v: f32) -> [f32; 2] {
     }
 }
 
+fn placeholder_destination(output: vk::Extent2D, texture: vk::Extent2D) -> [f32; 4] {
+    let min_side = output.width.min(output.height) as f32;
+    let max_dim = min_side * 0.40;
+    let aspect = texture.width as f32 / texture.height.max(1) as f32;
+    let (dest_w, dest_h) = if aspect >= 1.0 {
+        (max_dim, max_dim / aspect.max(f32::EPSILON))
+    } else {
+        (max_dim * aspect, max_dim)
+    };
+    let x = (output.width as f32 - dest_w) * 0.5;
+    let y = (output.height as f32 - dest_h) * 0.5;
+    [x, y, dest_w, dest_h]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2853,6 +3227,24 @@ mod tests {
         let mut state = BlankState::Pending;
         state.abandon();
         assert_eq!(state, BlankState::Inactive);
+    }
+
+    #[test]
+    fn placeholder_destination_centers_a_square_icon() {
+        let dest = placeholder_destination(
+            vk::Extent2D {
+                width: 1920,
+                height: 1080,
+            },
+            vk::Extent2D {
+                width: 1024,
+                height: 1024,
+            },
+        );
+        assert_near(dest[2], 1080.0 * 0.40);
+        assert_near(dest[3], 1080.0 * 0.40);
+        assert_near(dest[0] + dest[2] / 2.0, 960.0);
+        assert_near(dest[1] + dest[3] / 2.0, 540.0);
     }
 
     #[test]


### PR DESCRIPTION
Show a branded empty state (Waywallen logo on `#D85A30`, plus “No wallpaper selected”) whenever there is nothing to present.

## Changes
- **KDE Plasma**: overlay in the wallpaper QML. Visible when `framesReceived === 0` or the plugin is not connected. The SVG ships with the kpackage.
- **GNOME Shell**: desktop `LiveWallpaper` placeholder, gated on the renderer’s `hasFrame` title hint. The gobject paintable fills `#D85A30` until the first composition.
- **layer-shell**: `build.rs` rasterizes the SVG with `resvg`. A `BlankState` machine commits the empty frame once, rearms on swapchain recreate, and yields as soon as a producer frame arrives.


issue: https://github.com/waywallen/waywallen-display/issues/41