### PR TITLE
layershell: add COSMIC window-state watcher (auto-pause support)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,9 +587,11 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "wayland-backend",
  "wayland-client",
  "wayland-protocols",
  "wayland-protocols-wlr",
+ "wayland-scanner",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ layer-shell = [
     "dep:wayland-client",
     "dep:wayland-protocols",
     "dep:wayland-protocols-wlr",
+    "dep:wayland-scanner",
+    "dep:wayland-backend",
     "dep:niri-ipc",
     "dep:md-5",
 ]
@@ -45,6 +47,8 @@ serde_json = { version = "1.0", optional = true }
 wayland-client = { version = "0.31", features = ["system"], optional = true }
 wayland-protocols = { version = "0.32", features = ["client", "unstable", "staging"], optional = true }
 wayland-protocols-wlr = { version = "0.3", features = ["client"], optional = true }
+wayland-scanner = { version = "0.31", optional = true }
+wayland-backend = { version = "0.3", default-features = false, optional = true }
 niri-ipc = { version = "26.4.0", optional = true }
 md-5 = { version = "0.10", optional = true }
 
@@ -55,5 +59,4 @@ pkg-config = "0.3"
 [[bin]]
 name = "waywallen-layer-shell"
 path = "src/bin/layer_shell/main.rs"
-test = false
 required-features = ["layer-shell"]

--- a/src/bin/layer_shell/protocols/cosmic-toplevel-info-unstable-v1.xml
+++ b/src/bin/layer_shell/protocols/cosmic-toplevel-info-unstable-v1.xml
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Vendored from https://github.com/pop-os/cosmic-protocols
+  (unstable/cosmic-toplevel-info-unstable-v1.xml), with one deviation:
+  the v1-only workspace_enter / workspace_leave events are removed
+  because this client binds version 2+ only (see cosmic_toplevel_info.rs).
+-->
+<protocol name="cosmic_toplevel_info_unstable_v1">
+  <copyright>
+    Copyright © 2018 Ilia Bozhinov
+    Copyright © 2020 Isaac Freund
+    Copyright © 2024 Victoria Brekenfeld
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <interface name="zcosmic_toplevel_info_v1" version="3">
+    <description summary="list toplevels and properties thereof">
+      The purpose of this protocol is to enable clients such as taskbars
+      or docks to access a list of opened applications and basic properties
+      thereof.
+
+      It thus extends ext_foreign_toplevel_v1 to provide more information
+      and actions on foreign toplevels.
+    </description>
+
+    <event name="toplevel" deprecated-since="2">
+      <description summary="a toplevel has been created">
+        This event is never emitted for clients binding version 2
+        of this protocol, they should use `get_cosmic_toplevel` instead.
+
+        This event is emitted for clients binding version 1 whenever a
+        new toplevel window is created. It is emitted for all toplevels,
+        regardless of the app that has created them.
+
+        All initial properties of the toplevel (title, app_id, states, etc.)
+        will be sent immediately after this event via the corresponding
+        events in zcosmic_toplevel_handle_v1.
+      </description>
+      <arg name="toplevel" type="new_id" interface="zcosmic_toplevel_handle_v1"/>
+    </event>
+
+    <request name="stop" deprecated-since="2">
+      <description summary="stop sending events">
+        This request indicates that the client no longer wishes to receive
+        events for new toplevels.  However, the compositor may emit further
+        toplevel_created events until the finished event is emitted.
+
+        The client must not send any more requests after this one.
+
+        Note: This request isn't necessary for clients binding version 2
+        of this protocol and will be ignored.
+      </description>
+    </request>
+
+    <event name="finished" deprecated-since="2">
+      <description summary="the compositor has finished with the toplevel manager">
+        This event indicates that the compositor is done sending events
+        to the zcosmic_toplevel_info_v1. The server will destroy the
+        object immediately after sending this request, so it will become
+        invalid and the client should free any resources associated with it.
+
+        Note: This event is emitted immediately after calling `stop` for
+        clients binding version 2 of this protocol for backwards compatibility.
+      </description>
+    </event>
+
+    <request name="get_cosmic_toplevel" since="2">
+      <description summary="get cosmic toplevel extension object">
+        Request a zcosmic_toplevel_handle_v1 extension object for an existing
+        ext_foreign_toplevel_handle_v1.
+
+        All initial properties of the toplevel (states, etc.)
+        will be sent immediately after this event via the corresponding
+        events in zcosmic_toplevel_handle_v1.
+      </description>
+      <arg name="cosmic_toplevel" type="new_id" interface="zcosmic_toplevel_handle_v1"/>
+      <arg name="foreign_toplevel" type="object" interface="ext_foreign_toplevel_handle_v1"/>
+    </request>
+
+    <event name="done" since="2">
+      <description summary="all information about active toplevels have been sent">
+        This event is sent after all changes for currently active
+        zcosmic_toplevel_handle_v1 have been sent.
+
+        This allows changes to multiple zcosmic_toplevel_handle_v1 handles
+        and their properties to be seen as atomic, even if they happen via
+        multiple events.
+      </description>
+    </event>
+  </interface>
+
+  <interface name="zcosmic_toplevel_handle_v1" version="3">
+    <description summary="an open toplevel">
+      A zcosmic_toplevel_handle_v1 object represents an open toplevel
+      window. A single app may have multiple open toplevels.
+
+      Each toplevel has a list of outputs it is visible on, exposed to the
+      client via the output_enter and output_leave events.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the zcosmic_toplevel_handle_v1 object">
+        This request should be called either when the client will no longer
+        use the zcosmic_toplevel_handle_v1.
+      </description>
+    </request>
+
+    <event name="closed" deprecated-since="2">
+      <description summary="the toplevel has been closed">
+        The server will emit no further events on the
+        zcosmic_toplevel_handle_v1 after this event. Any requests received
+        aside from the destroy request will be ignored. Upon receiving this
+        event, the client should make the destroy request to allow freeing
+        of resources.
+
+        Note: This event will not be emitted for clients binding version 2
+        of this protocol, as `ext_foreign_toplevel_handle_v1.closed` is
+        equivalent.
+      </description>
+    </event>
+
+    <event name="done" deprecated-since="2">
+      <description summary="all information about the toplevel has been sent">
+        This event is sent after all changes in the toplevel state have
+        been sent.
+
+        This allows changes to the zcosmic_toplevel_handle_v1 properties
+        to be seen as atomic, even if they happen via multiple events.
+
+        Note: this is is not sent after the closed event.
+
+        Note: This event will not be emitted for clients binding version 2
+        of this protocol, as `ext_foreign_toplevel_handle_v1.done` is
+        equivalent.
+      </description>
+    </event>
+
+    <event name="title" deprecated-since="2">
+      <description summary="title change">
+        This event is emitted whenever the title of the toplevel changes.
+
+        Note: This event will not be emitted for clients binding version 2
+        of this protocol, as `ext_foreign_toplevel_handle_v1.title` is
+        equivalent.
+      </description>
+      <arg name="title" type="string"/>
+    </event>
+
+    <event name="app_id" deprecated-since="2">
+      <description summary="app_id change">
+        This event is emitted whenever the app_id of the toplevel changes.
+
+        Note: This event will not be emitted for clients binding version 2
+        of this protocol, as `ext_foreign_toplevel_handle_v1.app_id` is
+        equivalent.
+      </description>
+      <arg name="app_id" type="string"/>
+    </event>
+
+    <event name="output_enter">
+      <description summary="toplevel entered an output">
+        This event is emitted whenever the toplevel becomes visible on the
+        given output. A toplevel may be visible on multiple outputs.
+      </description>
+      <arg name="output" type="object" interface="wl_output"/>
+    </event>
+
+    <event name="output_leave">
+      <description summary="toplevel left an output">
+        This event is emitted whenever the toplevel is no longer visible
+        on a given output. It is guaranteed that an output_enter event with
+        the same output has been emitted before this event.
+      </description>
+      <arg name="output" type="object" interface="wl_output"/>
+    </event>
+
+    <enum name="state">
+      <description summary="types of states on the toplevel">
+        The different states that a toplevel may have. These have the same
+        meaning as the states with the same names defined in xdg-toplevel
+      </description>
+      <entry name="maximized"  value="0" summary="the toplevel is maximized"  />
+      <entry name="minimized"  value="1" summary="the toplevel is minimized"  />
+      <entry name="activated"  value="2" summary="the toplevel is active"     />
+      <entry name="fullscreen" value="3" summary="the toplevel is fullscreen" />
+      <entry name="sticky"     value="4" summary="the toplevel is sticky"     since="2" />
+    </enum>
+
+    <event name="state">
+      <description summary="the toplevel state changed">
+        This event is emitted once on creation of the
+        zcosmic_toplevel_handle_v1 and again whenever the state of the
+        toplevel changes.
+      </description>
+      <arg name="state" type="array"/>
+    </event>
+
+    <event name="geometry" since="2">
+      <description summary="the toplevel's position and/or size has changed">
+        Emitted when the geometry of a toplevel (it's position and/or size)
+        relative to the provided output has changed.
+
+        This event is emitted once on creation of the
+        zcosmic_toplevel_handle_v1 for every entered output and again
+        whenever the geometry of the toplevel changes relative to any output.
+      </description>
+      <arg name="output" type="object" interface="wl_output"/>
+      <arg name="x" type="int" summary="x coordinate of the upper-left corner"/>
+      <arg name="y" type="int" summary="y coordinate of the upper-left corner"/>
+      <arg name="width" type="int" summary="width of the toplevel"/>
+      <arg name="height" type="int" summary="height of the toplevel"/>
+    </event>
+
+    <event name="ext_workspace_enter" since="3">
+      <description summary="toplevel entered an workspace">
+        This event is emitted whenever the toplevel becomes visible on the
+        given workspace. A toplevel may be visible on multiple workspaces.
+      </description>
+      <arg name="workspace" type="object" interface="ext_workspace_handle_v1"/>
+    </event>
+
+    <event name="ext_workspace_leave" since="3">
+      <description summary="toplevel left an workspace">
+        This event is emitted whenever the toplevel is no longer visible
+        on a given workspace. It is guaranteed that an workspace_enter event with
+        the same workspace has been emitted before this event.
+      </description>
+      <arg name="workspace" type="object" interface="ext_workspace_handle_v1"/>
+    </event>
+  </interface>
+</protocol>

--- a/src/bin/layer_shell/watcher/cosmic.rs
+++ b/src/bin/layer_shell/watcher/cosmic.rs
@@ -1,0 +1,871 @@
+//! Window-state watcher for COSMIC (cosmic-comp) over its own protocols.
+//!
+//! cosmic-comp ships neither the compositors' IPCs nor
+//! `zwlr_foreign_toplevel_management_v1` — it exposes the upstream
+//! `ext_foreign_toplevel_list_v1` plus two extensions instead:
+//!
+//! * `zcosmic_toplevel_info_v1` extends every toplevel with the
+//!   `maximized` / `minimized` / `activated` / `fullscreen` / `sticky`
+//!   state bits, `output_enter` / `output_leave`, and (since v3)
+//!   `ext_workspace_enter` / `ext_workspace_leave`.
+//! * `ext_workspace_manager_v1` announces every workspace and which of
+//!   them are currently active — exactly the piece the wlr fallback
+//!   fundamentally cannot know.
+//!
+//! Combining the two closes the gap that limits [`super::wlr`]: COSMIC
+//! keeps a window's `output_enter` set while its desktop is hidden, so
+//! the workspace events are what let windows parked on an inactive
+//! desktop drop out of the count instead of keeping `HAS_NON_MINIMIZED`
+//! et al. lit. Toplevels without workspace membership (sticky windows)
+//! or a missing workspace manager fall back to output-only accounting
+//! and err toward "visible".
+//!
+//! Upstream both globals sit behind cosmic-comp's `client_not_sandboxed`
+//! filter, i.e. they are open to every regular session client. The
+//! `ext_workspace_*` handles referenced by a toplevel are the very same
+//! resources the manager announced to us, because both globals were
+//! bound on this one connection — matching them by object id is sound.
+
+use super::cosmic_toplevel_info::{
+    zcosmic_toplevel_handle_v1::{self, State as ToplevelState, ZcosmicToplevelHandleV1},
+    zcosmic_toplevel_info_v1::{self, ZcosmicToplevelInfoV1},
+};
+use crate::watcher::{Command, CommandSender};
+use std::collections::{HashMap, HashSet};
+use std::thread;
+use wayland_client::backend::ObjectId;
+use wayland_client::globals::{registry_queue_init, GlobalListContents};
+use wayland_client::protocol::wl_output::{self, WlOutput};
+use wayland_client::protocol::wl_registry::{self, WlRegistry};
+use wayland_client::{
+    event_created_child, Connection, Dispatch, EventQueue, Proxy, QueueHandle,
+};
+use wayland_protocols::ext::foreign_toplevel_list::v1::client::{
+    ext_foreign_toplevel_handle_v1::{self, ExtForeignToplevelHandleV1},
+    ext_foreign_toplevel_list_v1::{self, ExtForeignToplevelListV1},
+};
+use wayland_protocols::ext::workspace::v1::client::{
+    ext_workspace_group_handle_v1::{self, ExtWorkspaceGroupHandleV1},
+    ext_workspace_handle_v1::{self, ExtWorkspaceHandleV1},
+    ext_workspace_manager_v1::{self, ExtWorkspaceManagerV1},
+};
+use wayland_client::WEnum;
+use waywallen_display::{
+    WAYWALLEN_WIN_HAS_ACTIVE, WAYWALLEN_WIN_HAS_FULLSCREEN, WAYWALLEN_WIN_HAS_MAXIMIZED,
+    WAYWALLEN_WIN_HAS_NON_MINIMIZED,
+};
+
+const FOREIGN_TOPLEVEL_LIST_INTERFACE: &str = "ext_foreign_toplevel_list_v1";
+const TOPLEVEL_INFO_INTERFACE: &str = "zcosmic_toplevel_info_v1";
+const WORKSPACE_MANAGER_INTERFACE: &str = "ext_workspace_manager_v1";
+
+/// Version 2 added `get_cosmic_toplevel`; everything before is legacy.
+const TOPLEVEL_INFO_VERSION: u32 = 3;
+/// The only version there is.
+const FOREIGN_TOPLEVEL_LIST_VERSION: u32 = 1;
+const WORKSPACE_MANAGER_VERSION: u32 = 1;
+
+/// `wl_output.name` carries the connector string the daemon knows each
+/// display by, and it needs version 4.
+const OUTPUT_VERSION: u32 = 4;
+
+pub fn detect() -> bool {
+    let Ok(connection) = Connection::connect_to_env() else {
+        return false;
+    };
+    let Ok((globals, _queue)) = registry_queue_init::<Probe>(&connection) else {
+        return false;
+    };
+    let mut foreign_toplevel_list = false;
+    let mut toplevel_info = false;
+    for global in globals.contents().clone_list() {
+        match global.interface.as_str() {
+            FOREIGN_TOPLEVEL_LIST_INTERFACE => foreign_toplevel_list = true,
+            TOPLEVEL_INFO_INTERFACE => toplevel_info = global.version >= 2,
+            _ => {}
+        }
+    }
+    foreign_toplevel_list && toplevel_info
+}
+
+struct Probe;
+
+impl Dispatch<WlRegistry, GlobalListContents> for Probe {
+    fn event(
+        _: &mut Self,
+        _: &WlRegistry,
+        _: wl_registry::Event,
+        _: &GlobalListContents,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+pub fn spawn(commands: CommandSender) {
+    thread::spawn(move || run_loop(commands));
+}
+
+fn run_loop(commands: CommandSender) {
+    let connection = match Connection::connect_to_env() {
+        Ok(connection) => connection,
+        Err(error) => {
+            log::error!("cosmic_watcher: connect to compositor: {error}");
+            return;
+        }
+    };
+    let (globals, queue) = match registry_queue_init::<Watcher>(&connection) {
+        Ok(pair) => pair,
+        Err(error) => {
+            log::error!("cosmic_watcher: registry init: {error}");
+            return;
+        }
+    };
+    let qh = queue.handle();
+    let mut watcher = Watcher::new(commands);
+    let mut foreign_toplevel_list = None;
+    let mut toplevel_info = None;
+    let mut workspace_manager = None;
+    for global in globals.contents().clone_list() {
+        match global.interface.as_str() {
+            FOREIGN_TOPLEVEL_LIST_INTERFACE => {
+                foreign_toplevel_list = Some(
+                    globals
+                        .registry()
+                        .bind::<ExtForeignToplevelListV1, _, _>(
+                            global.name,
+                            global.version.min(FOREIGN_TOPLEVEL_LIST_VERSION),
+                            &qh,
+                            (),
+                        ),
+                );
+            }
+            TOPLEVEL_INFO_INTERFACE if global.version >= 2 => {
+                toplevel_info = Some(
+                    globals
+                        .registry()
+                        .bind::<ZcosmicToplevelInfoV1, _, _>(
+                            global.name,
+                            global.version.min(TOPLEVEL_INFO_VERSION),
+                            &qh,
+                            (),
+                        ),
+                );
+            }
+            WORKSPACE_MANAGER_INTERFACE => {
+                // Optional: without it every toplevel counts as visible,
+                // which degrades to the wlr fallback's blind spots.
+                workspace_manager = Some(
+                    globals
+                        .registry()
+                        .bind::<ExtWorkspaceManagerV1, _, _>(
+                            global.name,
+                            global.version.min(WORKSPACE_MANAGER_VERSION),
+                            &qh,
+                            (),
+                        ),
+                );
+            }
+            "wl_output" => {
+                watcher.bind_output(globals.registry(), global.name, global.version, &qh)
+            }
+            _ => {}
+        }
+    }
+    let (Some(_foreign_toplevel_list), Some(toplevel_info)) =
+        (foreign_toplevel_list, toplevel_info)
+    else {
+        log::error!(
+            "cosmic_watcher: compositor does not expose {FOREIGN_TOPLEVEL_LIST_INTERFACE} \
+             with {TOPLEVEL_INFO_INTERFACE} v2+"
+        );
+        return;
+    };
+    if workspace_manager.is_none() {
+        log::debug!(
+            "cosmic_watcher: no {WORKSPACE_MANAGER_INTERFACE}, \
+             hidden-desktop filtering disabled"
+        );
+    }
+    log::info!(
+        "cosmic_watcher: enabled ({TOPLEVEL_INFO_INTERFACE} v{}, \
+         {WORKSPACE_MANAGER_INTERFACE} v{})",
+        toplevel_info.version(),
+        workspace_manager
+            .as_ref()
+            .map(Proxy::version)
+            .unwrap_or(0)
+    );
+    watcher.set_managers(toplevel_info);
+    run_dispatch(queue, watcher);
+}
+
+fn run_dispatch(mut queue: EventQueue<Watcher>, mut watcher: Watcher) {
+    // Binding the toplevel list makes the compositor announce every window
+    // it already has, so the first roundtrip is what fills in the state
+    // the daemon starts out with.
+    if let Err(error) = queue.roundtrip(&mut watcher) {
+        log::error!("cosmic_watcher: initial roundtrip: {error}");
+        return;
+    }
+    watcher.push_state();
+    loop {
+        if let Err(error) = queue.blocking_dispatch(&mut watcher) {
+            log::error!("cosmic_watcher: dispatch: {error}");
+            return;
+        }
+        if std::mem::take(&mut watcher.dirty) {
+            watcher.push_state();
+        }
+    }
+}
+
+struct Output {
+    global: u32,
+    display_name: Option<String>,
+}
+
+#[derive(Default)]
+struct Toplevel {
+    state: WindowState,
+    outputs: HashSet<ObjectId>,
+    workspaces: HashSet<ObjectId>,
+}
+
+#[derive(Default)]
+struct Workspace {
+    active: bool,
+}
+
+struct Watcher {
+    commands: CommandSender,
+    outputs: HashMap<ObjectId, Output>,
+    /// Keyed by the `ext_foreign_toplevel_handle_v1` id.
+    toplevels: HashMap<ObjectId, Toplevel>,
+    /// `zcosmic_toplevel_handle_v1` extension objects remember which
+    /// ext handle they belong to.
+    cosmic_handles: HashMap<ObjectId, ObjectId>,
+    workspaces: HashMap<ObjectId, Workspace>,
+    toplevel_info: Option<ZcosmicToplevelInfoV1>,
+    /// Turns true with the first announced workspace; until then the
+    /// accounting cannot filter anything.
+    tracking_workspaces: bool,
+    dirty: bool,
+}
+
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq)]
+struct WindowState {
+    maximized: bool,
+    minimized: bool,
+    activated: bool,
+    fullscreen: bool,
+    sticky: bool,
+}
+
+impl WindowState {
+    /// The payload is a `wl_array` of `zcosmic_toplevel_handle_v1.state`
+    /// values and every event replaces the previous state wholesale.
+    fn from_event(payload: &[u8]) -> Self {
+        let mut state = Self::default();
+        for value in payload.chunks_exact(4) {
+            let value = u32::from_ne_bytes([value[0], value[1], value[2], value[3]]);
+            match ToplevelState::try_from(value) {
+                Ok(ToplevelState::Maximized) => state.maximized = true,
+                Ok(ToplevelState::Minimized) => state.minimized = true,
+                Ok(ToplevelState::Activated) => state.activated = true,
+                Ok(ToplevelState::Fullscreen) => state.fullscreen = true,
+                Ok(ToplevelState::Sticky) => state.sticky = true,
+                Err(_) => log::debug!("cosmic_watcher: unknown toplevel state {value}"),
+            }
+        }
+        state
+    }
+
+    /// A minimized window is off screen, so it contributes nothing.
+    /// Sticky has no bit of its own; it only matters for [`Watcher`].
+    fn to_flags(self) -> u32 {
+        if self.minimized {
+            return 0;
+        }
+        let mut flags = WAYWALLEN_WIN_HAS_NON_MINIMIZED;
+        if self.activated {
+            flags |= WAYWALLEN_WIN_HAS_ACTIVE
+        }
+        if self.maximized {
+            flags |= WAYWALLEN_WIN_HAS_MAXIMIZED
+        }
+        if self.fullscreen {
+            flags |= WAYWALLEN_WIN_HAS_FULLSCREEN
+        }
+        flags
+    }
+}
+
+impl Watcher {
+    fn new(commands: CommandSender) -> Self {
+        Self {
+            commands,
+            outputs: HashMap::new(),
+            toplevels: HashMap::new(),
+            cosmic_handles: HashMap::new(),
+            workspaces: HashMap::new(),
+            toplevel_info: None,
+            tracking_workspaces: false,
+            dirty: false,
+        }
+    }
+
+    /// Keeps the toplevel-info proxy around: new windows need it to ask
+    /// for their `zcosmic_toplevel_handle_v1` extension object.
+    fn set_managers(&mut self, toplevel_info: ZcosmicToplevelInfoV1) {
+        self.toplevel_info = Some(toplevel_info);
+    }
+
+    fn bind_output(
+        &mut self,
+        registry: &WlRegistry,
+        global: u32,
+        version: u32,
+        qh: &QueueHandle<Self>,
+    ) {
+        if version < OUTPUT_VERSION {
+            log::warn!(
+                "cosmic_watcher: wl_output v{version} has no name event, \
+                 display {global} cannot be matched"
+            );
+            return;
+        }
+        let output = registry.bind::<WlOutput, _, _>(global, OUTPUT_VERSION, qh, ());
+        self.outputs.insert(
+            output.id(),
+            Output {
+                global,
+                display_name: None,
+            },
+        );
+    }
+
+    fn drop_output(&mut self, global: u32) {
+        self.outputs.retain(|_, output| output.global != global);
+        self.dirty = true;
+    }
+
+    /// A window counts toward a display while at least one of its
+    /// workspaces is showing on it. Without workspace knowledge there is
+    /// nothing to go on, and sticky windows show up everywhere anyway.
+    fn is_visible(&self, toplevel: &Toplevel) -> bool {
+        toplevel.state.sticky
+            || !self.tracking_workspaces
+            || toplevel.workspaces.is_empty()
+            || toplevel
+                .workspaces
+                .iter()
+                .any(|id| self.workspaces.get(id).is_some_and(|ws| ws.active))
+    }
+
+    fn aggregate_flags(&self) -> HashMap<String, u32> {
+        let mut by_output: HashMap<String, u32> = HashMap::new();
+        for toplevel in self.toplevels.values() {
+            let flags = toplevel.state.to_flags();
+            if flags == 0 || !self.is_visible(toplevel) {
+                continue;
+            }
+            for output in &toplevel.outputs {
+                let Some(display_name) = self
+                    .outputs
+                    .get(output)
+                    .and_then(|output| output.display_name.clone())
+                else {
+                    continue;
+                };
+                *by_output.entry(display_name).or_insert(0) |= flags;
+            }
+        }
+        by_output
+    }
+
+    fn push_state(&self) {
+        let by_output = self.aggregate_flags();
+        for display_name in self
+            .outputs
+            .values()
+            .filter_map(|output| output.display_name.as_deref())
+        {
+            let flags = by_output.get(display_name).copied().unwrap_or(0);
+            log::debug!("cosmic_watcher: {display_name} flags: {flags}");
+            self.commands.send(Command::WindowState {
+                display_name: display_name.to_string(),
+                flags,
+            });
+        }
+    }
+}
+
+impl Dispatch<WlRegistry, GlobalListContents> for Watcher {
+    fn event(
+        state: &mut Self,
+        registry: &WlRegistry,
+        event: wl_registry::Event,
+        _: &GlobalListContents,
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        match event {
+            wl_registry::Event::Global {
+                name,
+                interface,
+                version,
+            } if interface == "wl_output" => state.bind_output(registry, name, version, qh),
+            wl_registry::Event::GlobalRemove { name } => state.drop_output(name),
+            _ => {}
+        }
+    }
+}
+
+impl Dispatch<WlOutput, ()> for Watcher {
+    fn event(
+        state: &mut Self,
+        output: &WlOutput,
+        event: wl_output::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let wl_output::Event::Name { name } = event else {
+            return;
+        };
+        let Some(entry) = state.outputs.get_mut(&output.id()) else {
+            return;
+        };
+        log::debug!("cosmic_watcher: wl_output {} is '{name}'", entry.global);
+        entry.display_name = Some(name);
+        state.dirty = true;
+    }
+}
+
+impl Dispatch<ExtForeignToplevelListV1, ()> for Watcher {
+    fn event(
+        state: &mut Self,
+        _: &ExtForeignToplevelListV1,
+        event: ext_foreign_toplevel_list_v1::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        match event {
+            ext_foreign_toplevel_list_v1::Event::Toplevel { toplevel } => {
+                let ext_id = toplevel.id();
+                state.toplevels.insert(ext_id.clone(), Toplevel::default());
+                // Ask for the extension object right away; the initial
+                // state batch arrives on it before the next done.
+                if let Some(info) = state.toplevel_info.as_ref() {
+                    let cosmic_handle = info.get_cosmic_toplevel(&toplevel, qh, ());
+                    state.cosmic_handles.insert(cosmic_handle.id(), ext_id);
+                }
+            }
+            ext_foreign_toplevel_list_v1::Event::Finished => {
+                log::info!("cosmic_watcher: compositor stopped the toplevel list");
+                state.toplevels.clear();
+                state.cosmic_handles.clear();
+                state.dirty = true;
+            }
+            _ => {}
+        }
+    }
+
+    event_created_child!(Watcher, ExtForeignToplevelListV1, [
+        ext_foreign_toplevel_list_v1::EVT_TOPLEVEL_OPCODE => (ExtForeignToplevelHandleV1, ()),
+    ]);
+}
+
+impl Dispatch<ExtForeignToplevelHandleV1, ()> for Watcher {
+    fn event(
+        state: &mut Self,
+        handle: &ExtForeignToplevelHandleV1,
+        event: ext_foreign_toplevel_handle_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        // title / app_id / identifier / done carry nothing we need.
+        let ext_foreign_toplevel_handle_v1::Event::Closed = event else {
+            return;
+        };
+        handle.destroy();
+        state.toplevels.remove(&handle.id());
+        state.cosmic_handles.retain(|_, ext| *ext != handle.id());
+        state.dirty = true;
+    }
+}
+
+impl Dispatch<ZcosmicToplevelInfoV1, ()> for Watcher {
+    fn event(
+        state: &mut Self,
+        _: &ZcosmicToplevelInfoV1,
+        event: zcosmic_toplevel_info_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        // The manager-wide done is the commit point of a refresh cycle.
+        if let zcosmic_toplevel_info_v1::Event::Done = event {
+            state.dirty = true;
+        }
+    }
+}
+
+impl Dispatch<ZcosmicToplevelHandleV1, ()> for Watcher {
+    fn event(
+        state: &mut Self,
+        handle: &ZcosmicToplevelHandleV1,
+        event: zcosmic_toplevel_handle_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        // title / app_id / geometry are irrelevant here, and done/closed
+        // only exist for v1 clients — removal arrives via the ext handle.
+        let Some(ext_id) = state.cosmic_handles.get(&handle.id()).cloned() else {
+            return;
+        };
+        match event {
+            zcosmic_toplevel_handle_v1::Event::State { state: reported } => {
+                let Some(toplevel) = state.toplevels.get_mut(&ext_id) else {
+                    return;
+                };
+                let new_state = WindowState::from_event(&reported);
+                if toplevel.state != new_state {
+                    log::debug!(
+                        "cosmic_watcher: toplevel {ext_id} state {:?}",
+                        toplevel.state
+                    );
+                    toplevel.state = new_state;
+                    state.dirty = true;
+                }
+            }
+            zcosmic_toplevel_handle_v1::Event::OutputEnter { output } => {
+                if let Some(toplevel) = state.toplevels.get_mut(&ext_id) {
+                    toplevel.outputs.insert(output.id());
+                    state.dirty = true;
+                }
+            }
+            zcosmic_toplevel_handle_v1::Event::OutputLeave { output } => {
+                if let Some(toplevel) = state.toplevels.get_mut(&ext_id) {
+                    toplevel.outputs.remove(&output.id());
+                    state.dirty = true;
+                }
+            }
+            zcosmic_toplevel_handle_v1::Event::ExtWorkspaceEnter { workspace } => {
+                if let Some(toplevel) = state.toplevels.get_mut(&ext_id) {
+                    toplevel.workspaces.insert(workspace.id());
+                    state.dirty = true;
+                }
+            }
+            zcosmic_toplevel_handle_v1::Event::ExtWorkspaceLeave { workspace } => {
+                if let Some(toplevel) = state.toplevels.get_mut(&ext_id) {
+                    toplevel.workspaces.remove(&workspace.id());
+                    state.dirty = true;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Dispatch<ExtWorkspaceManagerV1, ()> for Watcher {
+    fn event(
+        state: &mut Self,
+        _: &ExtWorkspaceManagerV1,
+        event: ext_workspace_manager_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        match event {
+            ext_workspace_manager_v1::Event::Workspace { workspace, .. } => {
+                state.workspaces.insert(workspace.id(), Workspace::default());
+                state.tracking_workspaces = true;
+                state.dirty = true;
+            }
+            ext_workspace_manager_v1::Event::Done => state.dirty = true,
+            ext_workspace_manager_v1::Event::Finished => {
+                log::info!("cosmic_watcher: compositor stopped the workspace manager");
+                state.workspaces.clear();
+                state.tracking_workspaces = false;
+                state.dirty = true;
+            }
+            _ => {}
+        }
+    }
+
+    event_created_child!(Watcher, ExtWorkspaceManagerV1, [
+        ext_workspace_manager_v1::EVT_WORKSPACE_GROUP_OPCODE => (ExtWorkspaceGroupHandleV1, ()),
+        ext_workspace_manager_v1::EVT_WORKSPACE_OPCODE => (ExtWorkspaceHandleV1, ()),
+    ]);
+}
+
+impl Dispatch<ExtWorkspaceGroupHandleV1, ()> for Watcher {
+    fn event(
+        _: &mut Self,
+        group: &ExtWorkspaceGroupHandleV1,
+        event: ext_workspace_group_handle_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        // Groups only relate workspaces to outputs; per-toplevel output
+        // enter/leave already covers that mapping.
+        if let ext_workspace_group_handle_v1::Event::Removed = event {
+            group.destroy();
+        }
+    }
+}
+
+impl Dispatch<ExtWorkspaceHandleV1, ()> for Watcher {
+    fn event(
+        state: &mut Self,
+        handle: &ExtWorkspaceHandleV1,
+        event: ext_workspace_handle_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        match event {
+            ext_workspace_handle_v1::Event::State { state: reported } => {
+                // A bitmask, not a list: missing bits convey the opposite
+                // meaning, and combined bits decode as Unknown — so take
+                // the raw value and test the active bit.
+                let raw = match reported {
+                    WEnum::Value(value) => u32::from(value),
+                    WEnum::Unknown(raw) => raw,
+                };
+                let Some(workspace) = state.workspaces.get_mut(&handle.id()) else {
+                    return;
+                };
+                let active =
+                    raw & u32::from(ext_workspace_handle_v1::State::Active) != 0;
+                if workspace.active != active {
+                    workspace.active = active;
+                    state.dirty = true;
+                }
+            }
+            ext_workspace_handle_v1::Event::Removed => {
+                handle.destroy();
+                state.workspaces.remove(&handle.id());
+                state.dirty = true;
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::watcher::command_channel;
+
+    fn payload(states: &[ToplevelState]) -> Vec<u8> {
+        states
+            .iter()
+            .flat_map(|state| u32::from(*state).to_ne_bytes())
+            .collect()
+    }
+
+    fn watcher() -> Watcher {
+        let (sender, _receiver) = command_channel().unwrap();
+        Watcher::new(sender)
+    }
+
+    /// Null object ids are all we need: the maps only ever compare keys
+    /// against each other, and every test uses at most one id per kind.
+    fn null_id() -> ObjectId {
+        ObjectId::null()
+    }
+
+    fn output_named(name: &str) -> (ObjectId, Output) {
+        (
+            null_id(),
+            Output {
+                global: 1,
+                display_name: Some(name.to_string()),
+            },
+        )
+    }
+
+    #[test]
+    fn empty_state_is_a_plain_window() {
+        let state = WindowState::from_event(&payload(&[]));
+        assert_eq!(state, WindowState::default());
+        assert_eq!(state.to_flags(), WAYWALLEN_WIN_HAS_NON_MINIMIZED);
+    }
+
+    #[test]
+    fn every_state_maps_onto_its_bit() {
+        assert_eq!(
+            WindowState::from_event(&payload(&[ToplevelState::Activated])).to_flags(),
+            WAYWALLEN_WIN_HAS_NON_MINIMIZED | WAYWALLEN_WIN_HAS_ACTIVE
+        );
+        assert_eq!(
+            WindowState::from_event(&payload(&[ToplevelState::Maximized, ToplevelState::Activated]))
+                .to_flags(),
+            WAYWALLEN_WIN_HAS_NON_MINIMIZED
+                | WAYWALLEN_WIN_HAS_ACTIVE
+                | WAYWALLEN_WIN_HAS_MAXIMIZED
+        );
+        assert_eq!(
+            WindowState::from_event(&payload(&[
+                ToplevelState::Activated,
+                ToplevelState::Fullscreen
+            ]))
+            .to_flags(),
+            WAYWALLEN_WIN_HAS_NON_MINIMIZED | WAYWALLEN_WIN_HAS_ACTIVE | WAYWALLEN_WIN_HAS_FULLSCREEN
+        );
+        // Sticky is tracked but has no flag of its own.
+        let sticky = WindowState::from_event(&payload(&[ToplevelState::Sticky]));
+        assert!(sticky.sticky);
+        assert_eq!(sticky.to_flags(), WAYWALLEN_WIN_HAS_NON_MINIMIZED);
+    }
+
+    #[test]
+    fn minimized_windows_contribute_nothing() {
+        assert_eq!(
+            WindowState::from_event(&payload(&[ToplevelState::Minimized, ToplevelState::Activated]))
+                .to_flags(),
+            0
+        );
+    }
+
+    #[test]
+    fn a_truncated_array_is_ignored() {
+        assert_eq!(
+            WindowState::from_event(&[0x02, 0x00, 0x00]),
+            WindowState::default()
+        );
+    }
+
+    #[test]
+    fn flags_are_attributed_per_display() {
+        let mut w = watcher();
+        let (output_id, output) = output_named("DP-1");
+        w.outputs.insert(output_id.clone(), output);
+        w.toplevels.insert(
+            null_id(),
+            Toplevel {
+                state: WindowState {
+                    activated: true,
+                    ..Default::default()
+                },
+                outputs: [output_id].into(),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            w.aggregate_flags(),
+            HashMap::from([(
+                "DP-1".to_string(),
+                WAYWALLEN_WIN_HAS_NON_MINIMIZED | WAYWALLEN_WIN_HAS_ACTIVE
+            )])
+        );
+    }
+
+    #[test]
+    fn a_window_on_an_inactive_workspace_is_skipped() {
+        let mut w = watcher();
+        let (output_id, output) = output_named("DP-1");
+        w.outputs.insert(output_id.clone(), output);
+        let workspace_id = null_id();
+        w.tracking_workspaces = true;
+        w.workspaces.insert(workspace_id.clone(), Workspace { active: false });
+        w.toplevels.insert(
+            null_id(),
+            Toplevel {
+                state: WindowState {
+                    maximized: true,
+                    activated: true,
+                    ..Default::default()
+                },
+                outputs: [output_id].into(),
+                workspaces: [workspace_id].into(),
+            },
+        );
+        assert!(w.aggregate_flags().is_empty());
+    }
+
+    #[test]
+    fn a_window_on_the_active_workspace_counts() {
+        let mut w = watcher();
+        let (output_id, output) = output_named("DP-1");
+        w.outputs.insert(output_id.clone(), output);
+        let workspace_id = null_id();
+        w.tracking_workspaces = true;
+        w.workspaces.insert(workspace_id.clone(), Workspace { active: true });
+        w.toplevels.insert(
+            null_id(),
+            Toplevel {
+                state: WindowState {
+                    fullscreen: true,
+                    activated: true,
+                    ..Default::default()
+                },
+                outputs: [output_id].into(),
+                workspaces: [workspace_id].into(),
+            },
+        );
+        assert_eq!(
+            w.aggregate_flags()["DP-1"],
+            WAYWALLEN_WIN_HAS_NON_MINIMIZED
+                | WAYWALLEN_WIN_HAS_ACTIVE
+                | WAYWALLEN_WIN_HAS_FULLSCREEN
+        );
+    }
+
+    #[test]
+    fn sticky_windows_are_always_visible() {
+        let mut w = watcher();
+        let (output_id, output) = output_named("DP-1");
+        w.outputs.insert(output_id.clone(), output);
+        let workspace_id = null_id();
+        w.tracking_workspaces = true;
+        w.workspaces.insert(workspace_id.clone(), Workspace { active: false });
+        w.toplevels.insert(
+            null_id(),
+            Toplevel {
+                state: WindowState {
+                    sticky: true,
+                    maximized: true,
+                    ..Default::default()
+                },
+                outputs: [output_id].into(),
+                workspaces: [workspace_id].into(),
+            },
+        );
+        assert_eq!(
+            w.aggregate_flags()["DP-1"],
+            WAYWALLEN_WIN_HAS_NON_MINIMIZED | WAYWALLEN_WIN_HAS_MAXIMIZED
+        );
+    }
+
+    #[test]
+    fn without_workspace_accounting_everything_counts() {
+        let mut w = watcher();
+        let (output_id, output) = output_named("DP-1");
+        w.outputs.insert(output_id.clone(), output);
+        w.toplevels.insert(
+            null_id(),
+            Toplevel {
+                state: WindowState {
+                    fullscreen: true,
+                    ..Default::default()
+                },
+                outputs: [output_id].into(),
+                workspaces: [null_id()].into(),
+            },
+        );
+        assert_eq!(
+            w.aggregate_flags()["DP-1"],
+            WAYWALLEN_WIN_HAS_NON_MINIMIZED | WAYWALLEN_WIN_HAS_FULLSCREEN
+        );
+    }
+}
+
+

--- a/src/bin/layer_shell/watcher/cosmic_toplevel_info.rs
+++ b/src/bin/layer_shell/watcher/cosmic_toplevel_info.rs
@@ -1,0 +1,43 @@
+//! Client bindings for `cosmic_toplevel_info_unstable_v1`.
+//!
+//! The protocol definition is vendored at
+//! `protocols/cosmic-toplevel-info-unstable-v1.xml` (MIT-style license,
+//! see the file header) and expanded by `wayland-scanner` at compile
+//! time. The module layout mirrors what `wayland-protocols`' own
+//! `wayland_protocol!` macro produces, including the `__interfaces`
+//! module and the imports of every interface the XML references:
+//! `wl_output`, `ext_foreign_toplevel_handle_v1` and
+//! `ext_workspace_handle_v1`.
+//!
+//! One deviation from upstream: the v1-only `workspace_enter` /
+//! `workspace_leave` events (deprecated since v3 in favor of their
+//! `ext_workspace_*` twins) are stripped from the vendored copy so the
+//! generated code does not need the separate cosmic-workspace protocol.
+//! The watcher only ever binds version 2+, which never receives them.
+
+#![allow(dead_code, non_camel_case_types, unused_variables, unused_unsafe)]
+#![allow(non_upper_case_globals, non_snake_case, unused_imports)]
+
+use wayland_client;
+use wayland_client::protocol::*;
+use wayland_protocols::ext::foreign_toplevel_list::v1::client::__interfaces as _ftl_interfaces;
+use wayland_protocols::ext::workspace::v1::client::__interfaces as _ws_interfaces;
+
+pub mod __interfaces {
+    use wayland_client::protocol::__interfaces::*;
+    pub use super::_ftl_interfaces::*;
+    pub use super::_ws_interfaces::*;
+    wayland_scanner::generate_interfaces!(
+        "src/bin/layer_shell/protocols/cosmic-toplevel-info-unstable-v1.xml"
+    );
+}
+use self::__interfaces::*;
+
+// The generated objects reference the interfaces this XML extends, so
+// their client types must be in scope for `generate_client_code!`.
+use wayland_protocols::ext::foreign_toplevel_list::v1::client::*;
+use wayland_protocols::ext::workspace::v1::client::*;
+
+wayland_scanner::generate_client_code!(
+    "src/bin/layer_shell/protocols/cosmic-toplevel-info-unstable-v1.xml"
+);

--- a/src/bin/layer_shell/watcher/mod.rs
+++ b/src/bin/layer_shell/watcher/mod.rs
@@ -6,6 +6,8 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 
+pub mod cosmic;
+pub mod cosmic_toplevel_info;
 pub mod hyprland;
 pub mod niri;
 pub mod wayfire;
@@ -57,7 +59,8 @@ pub fn new_registry() -> BindingRegistry {
 ///
 /// A compositor with its own IPC gets its own watcher: only that IPC can say
 /// which workspace is visible, and every window on a hidden one has to stay out
-/// of the count. [`wlr`] is the fallback for everything else.
+/// of the count. [`cosmic`] reads the same knowledge off COSMIC's own
+/// protocols, and [`wlr`] is the fallback for everything else.
 pub fn spawn_all(registry: BindingRegistry, commands: CommandSender) {
     if hyprland::detect_socket().is_some() {
         hyprland::spawn(registry, commands)
@@ -65,6 +68,8 @@ pub fn spawn_all(registry: BindingRegistry, commands: CommandSender) {
         niri::spawn(registry, commands)
     } else if wayfire::detect_socket().is_some() {
         wayfire::spawn(registry, commands)
+    } else if cosmic::detect() {
+        cosmic::spawn(commands)
     } else {
         wlr::spawn(commands)
     }


### PR DESCRIPTION
## Why

Auto-pause never fired on COSMIC: cosmic-comp ships neither the compositors'
IPCs nor `zwlr_foreign_toplevel_management_v1`, so `spawn_all()` fell through
to the wlr watcher, which bailed with "compositor does not expose
zwlr_foreign_toplevel_manager_v1" and no window-state flags ever reached the
daemon.

## How

New `watcher/cosmic.rs`, driven entirely by protocols cosmic-comp actually
exposes (verified against its source — both globals sit behind its
`client_not_sandboxed` filter, so any regular session client can bind them):

- `ext_foreign_toplevel_list_v1` lists windows,
- `zcosmic_toplevel_info_v1` adds the maximized / minimized / activated /
  fullscreen / sticky bits plus per-output `output_enter`/`output_leave`,
- `ext_workspace_manager_v1` reports which workspaces are active.

Combining the latter two closes the gap that limits the wlr fallback: COSMIC
keeps a window's output-enter set while its desktop is hidden, and the
workspace events are what let windows parked on an inactive desktop drop out
of the pause count. Sticky windows always count as visible; a missing
workspace manager degrades gracefully to output-only accounting.

## Notes

- The cosmic-toplevel-info XML is vendored (MIT-style license) and codegen'd
  at build time via `wayland-scanner`; the v1-only workspace events are
  stripped since we bind v2+ only. `ext-foreign-toplevel-list` and
  `ext-workspace` bindings come from wayland-protocols' staging modules.
- New optional deps: `wayland-scanner` and `wayland-backend` (needed for the
  scanner macro expansion), both behind the existing `layer-shell` feature.
- Also removes `test = false` from the `[[bin]]` section — it silently
  prevented all watcher unit tests from ever compiling. They run now.
- 9 new unit tests (state parsing, flag mapping, workspace-visibility
  gating); full suite passes 38/38.
- **Not yet tested on real hardware** — verified against cosmic-comp's source
  and protocol specs only. A live COSMIC session check would be appreciated:
  watch the `cosmic_watcher:` debug logs while fullscreening a window and
  switching desktops.

## Transparency

This change was vibe coded — largely written by an AI agent (opencode)
working from protocol research against cosmic-comp's implementation. Human
review is explicitly requested, particularly around the Wayland event
handling and the version-negotiation paths.