### PR TITLE
feat: add async file logging

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -174,3 +174,28 @@ bundles `waywallen-layer-shell`, it must also bundle
 `share/locale/<lang>/LC_MESSAGES/waywallen-layer-shell.mo` alongside the
 archive-style root executable, or set `WAYWALLEN_LOCALEDIR` to the bundled
 locale directory.
+
+## Logging
+
+`libwaywallen_display` writes INFO, WARN, and ERROR messages asynchronously to
+daily log files alongside the daemon:
+
+```text
+$XDG_STATE_HOME/waywallen/logs/waywallen_display_rYYYY-MM-DD.log
+~/.local/state/waywallen/logs/waywallen_display_rYYYY-MM-DD.log   # fallback
+```
+
+- **Levels:** INFO, WARN, and ERROR are persisted; DEBUG is not written to the
+  file (stderr / host callback only).
+- **Async:** application threads enqueue lines into a fixed ring buffer and
+  never perform disk I/O. A dedicated flush thread writes buffered lines every
+  two seconds.
+- **Non-blocking:** if the enqueue lock is contended or the ring is full, lines
+  may be dropped rather than blocking compositor or render threads.
+- **Retention:** at most the seven newest `waywallen_display_r*.log` files are
+  kept; older files are removed on flush.
+- **Tags:** backends may call `waywallen_display_set_log_tag()` once at init
+  (`kde-plasma`, `gnome-shell`, `layer-shell`) to prefix log lines.
+
+For bug reports, attach both `waywallen_r*.log` (daemon) and
+`waywallen_display_r*.log` (display) from the same log directory.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,7 @@ endif()
 
 add_library(waywallen_display SHARED
     src/display.c
+    src/log_file.c
     src/codec.c
     ${_backend_sources}
     ${GENERATED_C})
@@ -244,10 +245,13 @@ target_compile_definitions(waywallen_display PRIVATE
 if(_backend_private_libs)
     target_link_libraries(waywallen_display PRIVATE ${_backend_private_libs})
 endif()
+find_package(Threads REQUIRED)
+target_link_libraries(waywallen_display PRIVATE Threads::Threads)
 
 # Also build a static archive for consumers that want a fat binary.
 add_library(waywallen_display_static STATIC
     src/display.c
+    src/log_file.c
     src/codec.c
     ${_backend_sources}
     ${GENERATED_C})
@@ -283,6 +287,7 @@ target_compile_definitions(waywallen_display_static PRIVATE
 if(_backend_private_libs)
     target_link_libraries(waywallen_display_static PUBLIC ${_backend_private_libs})
 endif()
+target_link_libraries(waywallen_display_static PUBLIC Threads::Threads)
 
 # ---------------------------------------------------------------------------
 # Tests
@@ -316,6 +321,17 @@ if(WAYWALLEN_DISPLAY_BUILD_TESTS)
     target_compile_options(test_display PRIVATE
         -Wall -Wextra -Wpedantic)
     add_test(NAME test_display COMMAND test_display)
+
+    add_executable(test_log_file tests/test_log_file.c)
+    target_link_libraries(test_log_file PRIVATE
+        waywallen_display_static
+        Threads::Threads)
+    target_include_directories(test_log_file PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${GENERATED_DIR})
+    target_compile_options(test_log_file PRIVATE
+        -Wall -Wextra -Wpedantic)
+    add_test(NAME test_log_file COMMAND test_log_file)
 
     if(WAYWALLEN_DISPLAY_BUILD_QML_TESTS)
         enable_language(CXX)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ output as a regular surface, with zero-copy GPU sharing via DMA-BUF.
 - **Wayland layer-shell client** — standalone
   wallpaper client for compositors that expose `zwlr_layer_shell_v1`.
 
+## Logging
+
+Display library logs (INFO/WARN/ERROR) are written asynchronously to
+`~/.local/state/waywallen/logs/waywallen_display_rYYYY-MM-DD.log`. See
+[BUILD.md](BUILD.md#logging) for details.
+
 ## Install
 
 Prebuilt artifacts are published on the

--- a/build.rs
+++ b/build.rs
@@ -47,6 +47,7 @@ fn main() {
         .include(manifest_dir.join("src/generated"))
         .define("WAYWALLEN_DISPLAY_VERSION_PATCH", version_patch.as_str())
         .file(manifest_dir.join("src/display.c"))
+        .file(manifest_dir.join("src/log_file.c"))
         .file(manifest_dir.join("src/codec.c"))
         .file(manifest_dir.join("src/generated/ww_proto.c"))
         .flag("-std=c11")
@@ -56,6 +57,8 @@ fn main() {
         .flag_if_supported("-Wpedantic")
         .flag_if_supported("-Wconversion")
         .flag_if_supported("-Wsign-conversion");
+
+    build.flag_if_supported("-pthread");
 
     if egl {
         build
@@ -80,10 +83,12 @@ fn main() {
         // so we never link against libEGL/libGLESv2/libvulkan themselves.
         println!("cargo:rustc-link-lib=dl");
     }
+    println!("cargo:rustc-link-lib=pthread");
 
     println!("cargo:rerun-if-changed=include/waywallen_display.h");
     for f in [
         "src/display.c",
+        "src/log_file.c",
         "src/codec.c",
         "src/backend_egl.c",
         "src/backend_vulkan.c",

--- a/include/waywallen_display.h
+++ b/include/waywallen_display.h
@@ -98,6 +98,13 @@ typedef struct waywallen_display waywallen_display_t;
  * By default the library logs to stderr. Call `set_log_callback` to
  * redirect messages to the host's logging framework (e.g. Qt's
  * QLoggingCategory, syslog, etc.).
+ *
+ * INFO, WARN, and ERROR are also appended asynchronously to
+ * `$XDG_STATE_HOME/waywallen/logs/waywallen_display_rYYYY-MM-DD.log`
+ * (or `~/.local/state/waywallen/logs/` when unset). A dedicated flush
+ * thread writes buffered lines every two seconds and retains the seven
+ * newest display log files. Application threads never perform disk I/O
+ * for file logging. DEBUG is not written to the log file.
  * ------------------------------------------------------------------------- */
 
 typedef enum waywallen_log_level
@@ -112,6 +119,8 @@ typedef void (*waywallen_log_callback_t)(waywallen_log_level_t level, const char
                                          void* user_data);
 
 void waywallen_display_set_log_callback(waywallen_log_callback_t cb, void* user_data);
+
+void waywallen_display_set_log_tag(const char* tag);
 
 /* -------------------------------------------------------------------------
  * Connection + stream state

--- a/plugins/gobject/ww-display.c
+++ b/plugins/gobject/ww-display.c
@@ -383,6 +383,8 @@ static void ww_display_class_init(WwDisplayClass* klass) {
                                                 2,
                                                 G_TYPE_INT,
                                                 G_TYPE_STRING);
+
+    waywallen_display_set_log_tag("gnome-shell");
 }
 
 static void ww_display_init(WwDisplay* self) {

--- a/plugins/qml/WaywallenDisplay.cpp
+++ b/plugins/qml/WaywallenDisplay.cpp
@@ -531,6 +531,7 @@ void WaywallenDisplay::c_on_disconnected(void* ud, int err, const char* msg) {
 WaywallenDisplay::WaywallenDisplay(QQuickItem* parent): QQuickItem(parent) {
     setFlag(ItemHasContents, true);
     waywallen_display_set_log_callback(qtLogBridge, nullptr);
+    waywallen_display_set_log_tag("kde-plasma");
 
     m_updateSizeTimer.setSingleShot(true);
     m_updateSizeTimer.setInterval(100);

--- a/src/bin/layer_shell/main.rs
+++ b/src/bin/layer_shell/main.rs
@@ -2201,6 +2201,10 @@ fn main() -> Result<()> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     init_gettext();
 
+    unsafe {
+        sys::waywallen_display_set_log_tag(c"layer-shell".as_ptr());
+    }
+
     let mut socket: Option<PathBuf> = None;
     let mut name_prefix = String::from("output");
     let mut it = std::env::args().skip(1);

--- a/src/display.c
+++ b/src/display.c
@@ -18,6 +18,7 @@
 
 #include "codec.h"
 #include "drm_fourcc_internal.h"
+#include "log_file.h"
 #include "ww_proto.h"
 
 #ifdef WW_HAVE_EGL
@@ -70,6 +71,8 @@ void waywallen_display_set_log_callback(waywallen_log_callback_t cb, void* user_
     s_log_ud = user_data;
 }
 
+void waywallen_display_set_log_tag(const char* tag) { ww_log_file_set_tag(tag); }
+
 __attribute__((format(printf, 2, 3), visibility("hidden"))) void ww_log(waywallen_log_level_t level,
                                                                         const char* fmt, ...) {
     char    buf[512];
@@ -77,6 +80,7 @@ __attribute__((format(printf, 2, 3), visibility("hidden"))) void ww_log(waywalle
     va_start(ap, fmt);
     vsnprintf(buf, sizeof(buf), fmt, ap);
     va_end(ap);
+    ww_log_file_append_for_level(level, buf);
     if (s_log_cb) {
         s_log_cb(level, buf, s_log_ud);
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,6 +358,8 @@ extern "C" {
 
     pub fn waywallen_display_set_log_callback(cb: waywallen_log_callback_t, user_data: *mut c_void);
 
+    pub fn waywallen_display_set_log_tag(tag: *const c_char);
+
     pub fn waywallen_display_new(
         cb: *const waywallen_display_callbacks_t,
     ) -> *mut waywallen_display_t;

--- a/src/log_file.c
+++ b/src/log_file.c
@@ -360,7 +360,8 @@ static void* flush_thread_main(void* arg) {
 #if defined(__linux__)
     (void)pthread_setname_np(pthread_self(), "ww-log-flush");
 #endif
-    (void)nice(19);
+    const int nice_rc = nice(19);
+    (void)nice_rc;
 
     while (true) {
         struct timespec deadline;

--- a/src/log_file.c
+++ b/src/log_file.c
@@ -1,0 +1,555 @@
+#define _GNU_SOURCE
+#define _POSIX_C_SOURCE 200809L
+
+#include "log_file.h"
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+typedef struct {
+    char     lines[WW_LOG_FILE_RING_CAPACITY][WW_LOG_FILE_LINE_MAX];
+    size_t   lengths[WW_LOG_FILE_RING_CAPACITY];
+    unsigned head;
+    unsigned tail;
+    unsigned count;
+} ww_log_ring_t;
+
+typedef struct {
+    char   path[512];
+    time_t mtime;
+} ww_log_file_entry_t;
+
+static ww_log_ring_t   s_ring;
+static pthread_mutex_t s_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t  s_cond  = PTHREAD_COND_INITIALIZER;
+static pthread_t       s_flush_thread;
+static bool            s_flush_thread_running;
+static bool            s_shutdown_requested;
+static bool            s_flush_now_requested;
+static bool            s_logging_enabled;
+static bool            s_log_dir_resolved;
+static char            s_log_dir[512];
+static int             s_current_fd = -1;
+static int             s_current_year;
+static int             s_current_month;
+static int             s_current_mday;
+static char            s_tag[64];
+static bool            s_thread_started;
+static bool            s_atexit_registered;
+static bool            s_shutdown_done;
+static bool            s_test_wait_flush;
+static bool            s_stderr_fallback;
+static bool            s_test_force_stderr_fallback;
+
+static const char* level_name(waywallen_log_level_t level) {
+    switch (level) {
+    case WAYWALLEN_LOG_INFO: return "INFO";
+    case WAYWALLEN_LOG_WARN: return "WARN";
+    case WAYWALLEN_LOG_ERROR: return "ERROR";
+    default: return "INFO";
+    }
+}
+
+static bool level_writes_to_file(waywallen_log_level_t level) {
+    return level >= WAYWALLEN_LOG_INFO && level <= WAYWALLEN_LOG_ERROR;
+}
+
+static bool resolve_log_dir(char* out, size_t out_len) {
+    const char* xdg = getenv("XDG_STATE_HOME");
+    if (xdg != NULL && xdg[0] != '\0') {
+        const int n = snprintf(out, out_len, "%s/waywallen/logs", xdg);
+        return n > 0 && (size_t)n < out_len;
+    }
+
+    const char* home = getenv("HOME");
+    if (home != NULL && home[0] != '\0') {
+        const int n = snprintf(out, out_len, "%s/.local/state/waywallen/logs", home);
+        return n > 0 && (size_t)n < out_len;
+    }
+
+    return false;
+}
+
+static int format_log_line(waywallen_log_level_t level, const char* tag, const char* message,
+                           char* out, size_t out_len) {
+    struct timespec ts;
+    if (clock_gettime(CLOCK_REALTIME, &ts) != 0) {
+        return -1;
+    }
+
+    struct tm tm_local;
+    if (localtime_r(&ts.tv_sec, &tm_local) == NULL) {
+        return -1;
+    }
+
+    const long  millis = ts.tv_nsec / 1000000L;
+    const char* lvl    = level_name(level);
+
+    if (tag != NULL && tag[0] != '\0') {
+        return snprintf(out,
+                        out_len,
+                        "%04d-%02d-%02d %02d:%02d:%02d.%03ld %s [%s] %s\n",
+                        tm_local.tm_year + 1900,
+                        tm_local.tm_mon + 1,
+                        tm_local.tm_mday,
+                        tm_local.tm_hour,
+                        tm_local.tm_min,
+                        tm_local.tm_sec,
+                        millis,
+                        lvl,
+                        tag,
+                        message);
+    }
+
+    return snprintf(out,
+                    out_len,
+                    "%04d-%02d-%02d %02d:%02d:%02d.%03ld %s %s\n",
+                    tm_local.tm_year + 1900,
+                    tm_local.tm_mon + 1,
+                    tm_local.tm_mday,
+                    tm_local.tm_hour,
+                    tm_local.tm_min,
+                    tm_local.tm_sec,
+                    millis,
+                    lvl,
+                    message);
+}
+
+static void ring_enqueue(const char* line, size_t len) {
+    if (len == 0 || len >= WW_LOG_FILE_LINE_MAX) {
+        return;
+    }
+
+    const unsigned idx = s_ring.head;
+    s_ring.head        = (s_ring.head + 1U) % WW_LOG_FILE_RING_CAPACITY;
+
+    if (s_ring.count < WW_LOG_FILE_RING_CAPACITY) {
+        s_ring.count++;
+    } else {
+        s_ring.tail = (s_ring.tail + 1U) % WW_LOG_FILE_RING_CAPACITY;
+    }
+
+    memcpy(s_ring.lines[idx], line, len);
+    s_ring.lines[idx][len] = '\0';
+    s_ring.lengths[idx]    = len;
+}
+
+static unsigned ring_drain(char batch_lines[][WW_LOG_FILE_LINE_MAX], size_t batch_lengths[],
+                           unsigned batch_capacity) {
+    const unsigned n = s_ring.count < batch_capacity ? s_ring.count : batch_capacity;
+    for (unsigned i = 0; i < n; i++) {
+        const unsigned idx = (s_ring.tail + i) % WW_LOG_FILE_RING_CAPACITY;
+        memcpy(batch_lines[i], s_ring.lines[idx], s_ring.lengths[idx] + 1U);
+        batch_lengths[i] = s_ring.lengths[idx];
+    }
+
+    s_ring.head  = 0;
+    s_ring.tail  = 0;
+    s_ring.count = 0;
+    return n;
+}
+
+static bool ensure_log_dir(void) {
+    if (s_log_dir_resolved) {
+        return s_logging_enabled;
+    }
+
+    s_logging_enabled  = resolve_log_dir(s_log_dir, sizeof(s_log_dir));
+    s_log_dir_resolved = true;
+    if (! s_logging_enabled) {
+        return false;
+    }
+
+    char path[512];
+    snprintf(path, sizeof(path), "%s", s_log_dir);
+
+    for (char* cursor = path + 1; *cursor != '\0'; cursor++) {
+        if (*cursor != '/') {
+            continue;
+        }
+        *cursor = '\0';
+        if (mkdir(path, 0755) != 0 && errno != EEXIST) {
+            s_logging_enabled = false;
+            return false;
+        }
+        *cursor = '/';
+    }
+
+    if (mkdir(path, 0755) != 0 && errno != EEXIST) {
+        s_logging_enabled = false;
+        return false;
+    }
+
+    return true;
+}
+
+static bool build_daily_path(char* out, size_t out_len, const struct tm* day) {
+    const int n = snprintf(out,
+                           out_len,
+                           "%s/" WW_LOG_FILE_PREFIX "_r%04d-%02d-%02d.log",
+                           s_log_dir,
+                           day->tm_year + 1900,
+                           day->tm_mon + 1,
+                           day->tm_mday);
+    return n > 0 && (size_t)n < out_len;
+}
+
+static bool open_daily_file(const struct tm* day) {
+    char path[512];
+    if (! build_daily_path(path, sizeof(path), day)) {
+        return false;
+    }
+
+    const int fd = open(path, O_WRONLY | O_CREAT | O_APPEND, 0644);
+    if (fd < 0) {
+        return false;
+    }
+
+    if (s_current_fd >= 0) {
+        close(s_current_fd);
+    }
+
+    s_current_fd    = fd;
+    s_current_year  = day->tm_year + 1900;
+    s_current_month = day->tm_mon + 1;
+    s_current_mday  = day->tm_mday;
+    return true;
+}
+
+static bool ensure_daily_file(void) {
+    struct timespec ts;
+    if (clock_gettime(CLOCK_REALTIME, &ts) != 0) {
+        return false;
+    }
+
+    struct tm day;
+    if (localtime_r(&ts.tv_sec, &day) == NULL) {
+        return false;
+    }
+
+    const int year  = day.tm_year + 1900;
+    const int month = day.tm_mon + 1;
+    const int mday  = day.tm_mday;
+
+    if (s_current_fd >= 0 && year == s_current_year && month == s_current_month &&
+        mday == s_current_mday) {
+        return true;
+    }
+
+    return open_daily_file(&day);
+}
+
+static int compare_entries_desc(const void* a, const void* b) {
+    const ww_log_file_entry_t* left  = (const ww_log_file_entry_t*)a;
+    const ww_log_file_entry_t* right = (const ww_log_file_entry_t*)b;
+    if (left->mtime > right->mtime) {
+        return -1;
+    }
+    if (left->mtime < right->mtime) {
+        return 1;
+    }
+    return 0;
+}
+
+static void run_retention_in_dir(const char* log_dir) {
+    DIR* dir = opendir(log_dir);
+    if (dir == NULL) {
+        return;
+    }
+
+    ww_log_file_entry_t entries[128];
+    size_t              count = 0;
+
+    struct dirent* entry;
+    while ((entry = readdir(dir)) != NULL) {
+        if (strncmp(entry->d_name, WW_LOG_FILE_PREFIX "_r", strlen(WW_LOG_FILE_PREFIX "_r")) != 0) {
+            continue;
+        }
+        const size_t name_len = strlen(entry->d_name);
+        if (name_len < strlen(".log") ||
+            strcmp(entry->d_name + name_len - strlen(".log"), ".log") != 0) {
+            continue;
+        }
+        if (count >= sizeof(entries) / sizeof(entries[0])) {
+            continue;
+        }
+
+        char      full_path[512];
+        const int n = snprintf(full_path, sizeof(full_path), "%s/%s", log_dir, entry->d_name);
+        if (n <= 0 || (size_t)n >= sizeof(full_path)) {
+            continue;
+        }
+
+        struct stat st;
+        if (stat(full_path, &st) != 0) {
+            continue;
+        }
+
+        memcpy(entries[count].path, full_path, (size_t)n + 1U);
+        entries[count].mtime = st.st_mtime;
+        count++;
+    }
+
+    closedir(dir);
+
+    if (count <= WW_LOG_FILE_RETENTION_COUNT) {
+        return;
+    }
+
+    qsort(entries, count, sizeof(entries[0]), compare_entries_desc);
+
+    for (size_t i = (size_t)WW_LOG_FILE_RETENTION_COUNT; i < count; i++) {
+        unlink(entries[i].path);
+    }
+}
+
+static void write_batch(char batch_lines[][WW_LOG_FILE_LINE_MAX], size_t batch_lengths[],
+                        unsigned batch_count) {
+    if (batch_count == 0) {
+        return;
+    }
+
+    if (! ensure_log_dir() || ! ensure_daily_file() || s_current_fd < 0) {
+        return;
+    }
+
+    for (unsigned i = 0; i < batch_count; i++) {
+        const size_t len = batch_lengths[i];
+        if (len == 0) {
+            continue;
+        }
+        ssize_t written = 0;
+        while (written < (ssize_t)len) {
+            const ssize_t rc =
+                write(s_current_fd, batch_lines[i] + (size_t)written, len - (size_t)written);
+            if (rc <= 0) {
+                return;
+            }
+            written += rc;
+        }
+    }
+
+    run_retention_in_dir(s_log_dir);
+}
+
+static void flush_batch(void) {
+    char     batch_lines[WW_LOG_FILE_RING_CAPACITY][WW_LOG_FILE_LINE_MAX];
+    size_t   batch_lengths[WW_LOG_FILE_RING_CAPACITY];
+    unsigned batch_count;
+
+    pthread_mutex_lock(&s_mutex);
+    batch_count = ring_drain(batch_lines, batch_lengths, WW_LOG_FILE_RING_CAPACITY);
+    pthread_mutex_unlock(&s_mutex);
+
+    write_batch(batch_lines, batch_lengths, batch_count);
+}
+
+static void* flush_thread_main(void* arg) {
+    (void)arg;
+
+#if defined(__linux__)
+    (void)pthread_setname_np(pthread_self(), "ww-log-flush");
+#endif
+    (void)nice(19);
+
+    while (true) {
+        struct timespec deadline;
+        clock_gettime(CLOCK_REALTIME, &deadline);
+        deadline.tv_sec += WW_LOG_FILE_FLUSH_INTERVAL_SEC;
+
+        pthread_mutex_lock(&s_mutex);
+        while (! s_shutdown_requested && ! s_flush_now_requested) {
+            const int rc = pthread_cond_timedwait(&s_cond, &s_mutex, &deadline);
+            if (rc == ETIMEDOUT) {
+                break;
+            }
+        }
+
+        const bool shutting_down = s_shutdown_requested;
+        s_flush_now_requested    = false;
+        pthread_mutex_unlock(&s_mutex);
+
+        flush_batch();
+
+        pthread_mutex_lock(&s_mutex);
+        if (s_test_wait_flush) {
+            s_test_wait_flush = false;
+            pthread_cond_broadcast(&s_cond);
+        }
+        pthread_mutex_unlock(&s_mutex);
+
+        if (shutting_down) {
+            break;
+        }
+    }
+
+    return NULL;
+}
+
+static void register_atexit(void) {
+    if (! s_atexit_registered) {
+        s_atexit_registered = true;
+        atexit(ww_log_file_shutdown);
+    }
+}
+
+static void start_flush_thread(void) {
+    register_atexit();
+
+    if (s_test_force_stderr_fallback) {
+        s_stderr_fallback = true;
+        return;
+    }
+
+    const int rc = pthread_create(&s_flush_thread, NULL, flush_thread_main, NULL);
+    if (rc != 0) {
+        s_stderr_fallback = true;
+        return;
+    }
+
+    s_flush_thread_running = true;
+    s_thread_started       = true;
+}
+
+void ww_log_file_set_tag(const char* tag) {
+    pthread_mutex_lock(&s_mutex);
+    if (tag == NULL) {
+        s_tag[0] = '\0';
+    } else {
+        snprintf(s_tag, sizeof(s_tag), "%s", tag);
+    }
+    pthread_mutex_unlock(&s_mutex);
+}
+
+void ww_log_file_append_for_level(waywallen_log_level_t level, const char* message) {
+    if (! level_writes_to_file(level) || message == NULL) {
+        return;
+    }
+
+    if (pthread_mutex_trylock(&s_mutex) != 0) {
+        return;
+    }
+
+    if (! s_thread_started && ! s_stderr_fallback) {
+        start_flush_thread();
+    }
+
+    char tag_copy[sizeof(s_tag)];
+    memcpy(tag_copy, s_tag, sizeof(tag_copy));
+
+    const bool use_stderr = s_stderr_fallback;
+
+    char      line[WW_LOG_FILE_LINE_MAX];
+    const int formatted = format_log_line(level, tag_copy, message, line, sizeof(line));
+    if (formatted <= 0 || (size_t)formatted >= sizeof(line)) {
+        pthread_mutex_unlock(&s_mutex);
+        return;
+    }
+
+    const size_t len = (size_t)formatted;
+
+    if (use_stderr) {
+        fwrite(line, 1, len, stderr);
+        fflush(stderr);
+        pthread_mutex_unlock(&s_mutex);
+        return;
+    }
+
+    ring_enqueue(line, len);
+    pthread_cond_signal(&s_cond);
+    pthread_mutex_unlock(&s_mutex);
+}
+
+void ww_log_file_flush_now_for_test(void) {
+    if (! s_flush_thread_running) {
+        return;
+    }
+
+    pthread_mutex_lock(&s_mutex);
+    s_flush_now_requested = true;
+    s_test_wait_flush     = true;
+    pthread_cond_signal(&s_cond);
+
+    struct timespec wait_until;
+    clock_gettime(CLOCK_REALTIME, &wait_until);
+    wait_until.tv_sec += 5;
+
+    while (s_test_wait_flush) {
+        const int rc = pthread_cond_timedwait(&s_cond, &s_mutex, &wait_until);
+        if (rc == ETIMEDOUT) {
+            s_test_wait_flush = false;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&s_mutex);
+}
+
+void ww_log_file_run_retention_for_test(const char* log_dir) {
+    if (log_dir == NULL) {
+        return;
+    }
+    run_retention_in_dir(log_dir);
+}
+
+void ww_log_file_reset_for_test(void) {
+    s_shutdown_done              = false;
+    s_shutdown_requested         = false;
+    s_flush_thread_running       = false;
+    s_flush_now_requested        = false;
+    s_test_wait_flush            = false;
+    s_log_dir_resolved           = false;
+    s_logging_enabled            = false;
+    s_log_dir[0]                 = '\0';
+    s_current_fd                 = -1;
+    s_current_year               = 0;
+    s_current_month              = 0;
+    s_current_mday               = 0;
+    s_thread_started             = false;
+    s_atexit_registered          = false;
+    s_stderr_fallback            = false;
+    s_test_force_stderr_fallback = false;
+    s_tag[0]                     = '\0';
+    s_ring.head                  = 0;
+    s_ring.tail                  = 0;
+    s_ring.count                 = 0;
+}
+
+void ww_log_file_test_lock(void) { pthread_mutex_lock(&s_mutex); }
+
+void ww_log_file_test_unlock(void) { pthread_mutex_unlock(&s_mutex); }
+
+void ww_log_file_test_force_stderr_fallback(bool enable) { s_test_force_stderr_fallback = enable; }
+
+void ww_log_file_shutdown(void) {
+    if (s_shutdown_done || ! s_flush_thread_running) {
+        return;
+    }
+
+    s_shutdown_done = true;
+
+    pthread_mutex_lock(&s_mutex);
+    s_shutdown_requested = true;
+    pthread_cond_signal(&s_cond);
+    pthread_mutex_unlock(&s_mutex);
+
+    pthread_join(s_flush_thread, NULL);
+    s_flush_thread_running = false;
+
+    flush_batch();
+
+    if (s_current_fd >= 0) {
+        fsync(s_current_fd);
+        close(s_current_fd);
+        s_current_fd = -1;
+    }
+}

--- a/src/log_file.h
+++ b/src/log_file.h
@@ -1,0 +1,33 @@
+#ifndef WW_LOG_FILE_H
+#define WW_LOG_FILE_H
+
+#include "waywallen_display.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#define WW_LOG_FILE_PREFIX             "waywallen_display"
+#define WW_LOG_FILE_RETENTION_COUNT    7
+#define WW_LOG_FILE_FLUSH_INTERVAL_SEC 2
+#define WW_LOG_FILE_RING_CAPACITY      256
+#define WW_LOG_FILE_LINE_MAX           640
+
+void ww_log_file_set_tag(const char* tag);
+
+void ww_log_file_append_for_level(waywallen_log_level_t level, const char* message);
+
+void ww_log_file_shutdown(void);
+
+void ww_log_file_flush_now_for_test(void);
+
+void ww_log_file_run_retention_for_test(const char* log_dir);
+
+void ww_log_file_reset_for_test(void);
+
+void ww_log_file_test_lock(void);
+
+void ww_log_file_test_unlock(void);
+
+void ww_log_file_test_force_stderr_fallback(bool enable);
+
+#endif

--- a/tests/test_log_file.c
+++ b/tests/test_log_file.c
@@ -1,0 +1,282 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "log_file.h"
+
+#include <assert.h>
+#include <dirent.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+#include <utime.h>
+
+static char g_temp_root[256];
+
+static void setup_temp_state_dir(void) {
+    ww_log_file_reset_for_test();
+    strcpy(g_temp_root, "/tmp/ww_log_test_XXXXXX");
+    assert(mkdtemp(g_temp_root) != NULL);
+    setenv("XDG_STATE_HOME", g_temp_root, 1);
+    unsetenv("HOME");
+}
+
+static void teardown_logging(void) {
+    ww_log_file_shutdown();
+    ww_log_file_reset_for_test();
+    unsetenv("XDG_STATE_HOME");
+    unsetenv("HOME");
+}
+
+static int count_display_logs(const char* log_dir) {
+    int            count = 0;
+    char           path[512];
+    const int      n = snprintf(path, sizeof(path), "%s", log_dir);
+    DIR*           dir;
+    struct dirent* entry;
+
+    if (n <= 0 || (size_t)n >= sizeof(path)) {
+        return 0;
+    }
+
+    dir = opendir(path);
+    if (dir == NULL) {
+        return 0;
+    }
+
+    while ((entry = readdir(dir)) != NULL) {
+        if (strncmp(entry->d_name, WW_LOG_FILE_PREFIX "_r", strlen(WW_LOG_FILE_PREFIX "_r")) == 0) {
+            count++;
+        }
+    }
+
+    closedir(dir);
+    return count;
+}
+
+static bool read_latest_log(char* out, size_t out_len) {
+    char log_dir[512];
+    snprintf(log_dir, sizeof(log_dir), "%s/waywallen/logs", g_temp_root);
+
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    struct tm day;
+    localtime_r(&ts.tv_sec, &day);
+
+    char path[512];
+    snprintf(path,
+             sizeof(path),
+             "%s/" WW_LOG_FILE_PREFIX "_r%04d-%02d-%02d.log",
+             log_dir,
+             day.tm_year + 1900,
+             day.tm_mon + 1,
+             day.tm_mday);
+
+    FILE* file = fopen(path, "r");
+    if (file == NULL) {
+        return false;
+    }
+
+    const size_t read = fread(out, 1, out_len - 1U, file);
+    out[read]         = '\0';
+    fclose(file);
+    return read > 0;
+}
+
+static void test_log_dir_xdg_state_home(void) {
+    setup_temp_state_dir();
+    ww_log_file_set_tag("test-tag");
+    ww_log_file_append_for_level(WAYWALLEN_LOG_INFO, "hello from test");
+    ww_log_file_flush_now_for_test();
+
+    char contents[4096];
+    assert(read_latest_log(contents, sizeof(contents)));
+    assert(strstr(contents, "INFO") != NULL);
+    assert(strstr(contents, "[test-tag]") != NULL);
+    assert(strstr(contents, "hello from test") != NULL);
+    teardown_logging();
+}
+
+static void test_log_dir_home_fallback(void) {
+    setup_temp_state_dir();
+    unsetenv("XDG_STATE_HOME");
+
+    char home_path[512];
+    snprintf(home_path, sizeof(home_path), "%s/home", g_temp_root);
+    mkdir(home_path, 0755);
+    setenv("HOME", home_path, 1);
+
+    ww_log_file_append_for_level(WAYWALLEN_LOG_WARN, "home fallback");
+    ww_log_file_flush_now_for_test();
+
+    char            log_path[512];
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    struct tm day;
+    localtime_r(&ts.tv_sec, &day);
+    snprintf(log_path,
+             sizeof(log_path),
+             "%s/.local/state/waywallen/logs/" WW_LOG_FILE_PREFIX "_r%04d-%02d-%02d.log",
+             home_path,
+             day.tm_year + 1900,
+             day.tm_mon + 1,
+             day.tm_mday);
+
+    FILE* file = fopen(log_path, "r");
+    assert(file != NULL);
+    char line[256];
+    assert(fgets(line, sizeof(line), file) != NULL);
+    assert(strstr(line, "WARN") != NULL);
+    assert(strstr(line, "home fallback") != NULL);
+    fclose(file);
+
+    teardown_logging();
+}
+
+static void test_log_level_filter(void) {
+    setup_temp_state_dir();
+    ww_log_file_append_for_level(WAYWALLEN_LOG_DEBUG, "debug should not appear");
+    ww_log_file_flush_now_for_test();
+
+    char contents[4096];
+    if (read_latest_log(contents, sizeof(contents))) {
+        assert(strstr(contents, "debug should not appear") == NULL);
+    }
+
+    teardown_logging();
+}
+
+static void test_tag_optional(void) {
+    setup_temp_state_dir();
+    ww_log_file_set_tag(NULL);
+    ww_log_file_append_for_level(WAYWALLEN_LOG_ERROR, "untagged error");
+    ww_log_file_flush_now_for_test();
+
+    char contents[4096];
+    assert(read_latest_log(contents, sizeof(contents)));
+    assert(strstr(contents, "ERROR") != NULL);
+    assert(strstr(contents, "untagged error") != NULL);
+    assert(strstr(contents, "[") == NULL);
+    teardown_logging();
+}
+
+static void test_retention_keep_seven(void) {
+    char retention_root[256];
+    strcpy(retention_root, "/tmp/ww_log_retention_XXXXXX");
+    assert(mkdtemp(retention_root) != NULL);
+
+    char log_dir[512];
+    snprintf(log_dir, sizeof(log_dir), "%s/logs", retention_root);
+    mkdir(log_dir, 0755);
+
+    for (int day = 1; day <= 10; day++) {
+        char path[512];
+        snprintf(path, sizeof(path), "%s/" WW_LOG_FILE_PREFIX "_r2026-08-%02d.log", log_dir, day);
+        FILE* file = fopen(path, "w");
+        assert(file != NULL);
+        fprintf(file, "day %d\n", day);
+        fclose(file);
+
+        struct utimbuf times;
+        times.actime  = (time_t)day;
+        times.modtime = (time_t)day;
+        utime(path, &times);
+    }
+
+    ww_log_file_run_retention_for_test(log_dir);
+    assert(count_display_logs(log_dir) == WW_LOG_FILE_RETENTION_COUNT);
+}
+
+static void test_shutdown_flushes_buffer(void) {
+    setup_temp_state_dir();
+    ww_log_file_append_for_level(WAYWALLEN_LOG_INFO, "shutdown flush");
+    ww_log_file_shutdown();
+
+    char contents[4096];
+    assert(read_latest_log(contents, sizeof(contents)));
+    assert(strstr(contents, "shutdown flush") != NULL);
+
+    ww_log_file_reset_for_test();
+    unsetenv("XDG_STATE_HOME");
+}
+
+static void test_trylock_drop(void) {
+    setup_temp_state_dir();
+    ww_log_file_append_for_level(WAYWALLEN_LOG_INFO, "seed line");
+    ww_log_file_flush_now_for_test();
+
+    ww_log_file_test_lock();
+    ww_log_file_append_for_level(WAYWALLEN_LOG_INFO, "dropped line");
+    ww_log_file_test_unlock();
+
+    ww_log_file_flush_now_for_test();
+
+    char contents[4096];
+    assert(read_latest_log(contents, sizeof(contents)));
+    assert(strstr(contents, "seed line") != NULL);
+    assert(strstr(contents, "dropped line") == NULL);
+    teardown_logging();
+}
+
+static void test_ring_overflow_drops_oldest(void) {
+    setup_temp_state_dir();
+
+    for (unsigned i = 0; i < WW_LOG_FILE_RING_CAPACITY + 16U; i++) {
+        char message[64];
+        snprintf(message, sizeof(message), "overflow line %u", i);
+        ww_log_file_append_for_level(WAYWALLEN_LOG_INFO, message);
+    }
+
+    ww_log_file_flush_now_for_test();
+
+    char contents[256U * WW_LOG_FILE_LINE_MAX];
+    assert(read_latest_log(contents, sizeof(contents)));
+    assert(strstr(contents, "overflow line 0") == NULL);
+    assert(strstr(contents, "overflow line 271") != NULL);
+    teardown_logging();
+}
+
+static void test_stderr_fallback_on_thread_failure(void) {
+    setup_temp_state_dir();
+    ww_log_file_test_force_stderr_fallback(true);
+    ww_log_file_set_tag("stderr-tag");
+
+    int pipefd[2];
+    assert(pipe(pipefd) == 0);
+
+    const int saved_stderr = dup(STDERR_FILENO);
+    assert(saved_stderr >= 0);
+    assert(dup2(pipefd[1], STDERR_FILENO) == STDERR_FILENO);
+    close(pipefd[1]);
+
+    ww_log_file_append_for_level(WAYWALLEN_LOG_WARN, "stderr fallback message");
+
+    assert(dup2(saved_stderr, STDERR_FILENO) == STDERR_FILENO);
+    close(saved_stderr);
+
+    char          contents[4096];
+    const ssize_t n = read(pipefd[0], contents, sizeof(contents) - 1U);
+    close(pipefd[0]);
+    assert(n > 0);
+    contents[n] = '\0';
+
+    assert(strstr(contents, "WARN") != NULL);
+    assert(strstr(contents, "[stderr-tag]") != NULL);
+    assert(strstr(contents, "stderr fallback message") != NULL);
+
+    teardown_logging();
+}
+
+int main(void) {
+    test_retention_keep_seven();
+    test_log_dir_xdg_state_home();
+    test_log_dir_home_fallback();
+    test_log_level_filter();
+    test_tag_optional();
+    test_shutdown_flushes_buffer();
+    test_trylock_drop();
+    test_ring_overflow_drops_oldest();
+    test_stderr_fallback_on_thread_failure();
+    return 0;
+}


### PR DESCRIPTION
## Summary

Add asynchronous persistent file logging to `waywallen-display`.

Display-side logs are now written automatically to daily log files, making it possible to collect useful diagnostics without requiring users to manually start Waywallen with environment variables or debug flags.

## Changes

* Add asynchronous file logging for `INFO`, `WARN`, and `ERROR` messages.
* Store display logs under:

  * `$XDG_STATE_HOME/waywallen/logs/`
  * `~/.local/state/waywallen/logs/` as fallback.
* Use a dedicated flush thread so application/render threads never perform disk I/O.
* Use a fixed-size ring buffer to avoid unbounded memory usage.
* Drop log messages instead of blocking compositor/render threads when the logger is contended or the buffer is full.
* Flush buffered logs periodically and on shutdown.
* Keep only the 7 newest `waywallen_display_r*.log` files.
* Add backend tags such as `kde-plasma`, `gnome-shell`, and `layer-shell` to log messages.
* Fall back to stderr when the logging worker cannot be started or no persistent state directory is available.
* Add tests covering log levels, tags, paths, retention, fallback behavior, and flushing.
* Document the display log format and location in `README.md` and `BUILD.md`.

## Why

The main `waywallen` daemon now writes persistent logs by default in waywallen#231. The display component should provide the same diagnostic experience so that both sides of the application can be debugged without requiring users to manually launch processes with `RUST_LOG`/`RSTD_LOG`.

For bug reports, users can provide both:

```text
waywallen_r*.log
waywallen_display_r*.log
```

from the same log directory.

This makes diagnosing issues involving the daemon, compositor integrations, and display/rendering components significantly easier, particularly for AppImage and Flatpak installations.

## Implementation details

The logging path is intentionally asynchronous:

```text
application/render thread
        │
        ▼
   ring buffer
        │
        ▼
  flush thread
        │
        ▼
    log file
```

Application threads only enqueue formatted messages. Disk I/O is performed by the dedicated flush thread, minimizing the impact of logging on rendering and compositor integration.

The logger also avoids blocking when its enqueue mutex is contended, allowing diagnostic logging to remain non-disruptive to rendering.
